### PR TITLE
add cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+# (C) Copyright 2017-2020 UCAR.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+################################################################################
+# UFO Test Files
+################################################################################
+
+cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
+
+project( ufo_data VERSION 1.0.0 DESCRIPTION "UFO Test Files" )


### PR DESCRIPTION
## Description

Adds minimum CMakeLists.txt to ufo-data. 

### Issue(s) addressed
- partly https://github.com/JCSDA-internal/ioda/issues/71

## Acceptance Criteria (Definition of Done)

We can clone ufo-data repo with `ecbuild_bundle` command. 

## Dependencies
None

## Impact

None

## Test Data

None