### PR TITLE
update aod files with updated upgrader (now 2d vars)

### DIFF
--- a/testinput_tier_1/aod_obs_2018041500_m.nc4
+++ b/testinput_tier_1/aod_obs_2018041500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd36513f952fe58fa986b9fd430e34ba3ca4cf211dc838de8c054300f6eb3e8a
-size 55535
+oid sha256:b8bee86fbc91737b0333cf70a91112899f14f5b9a867ef00b43a242332cdaebc
+size 60904

--- a/testinput_tier_1/aod_obs_2018041500_s.nc4
+++ b/testinput_tier_1/aod_obs_2018041500_s.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63d4bd1a4cb66d9ad8ccbb6f17c43b7956806bac5a5fc14c89c24ce8813a0230
-size 50642
+oid sha256:6e4ebba5aa24269f72c326696aa53e513b0f3dc7b7c82954500dd3c943697c5b
+size 57593

--- a/testinput_tier_1/aod_viirs_obs_2018041500_m.nc4
+++ b/testinput_tier_1/aod_viirs_obs_2018041500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1caa3a700420e20baba05da097ee7edb021a93f37ded4848613a9839dbae0ac9
-size 60384
+oid sha256:3f613619735c69554d400bfa0fac6a33384de332067cd79a6193c7c0e19d78ec
+size 65833

--- a/testinput_tier_1/aod_viirs_obs_2018041500_s.nc4
+++ b/testinput_tier_1/aod_viirs_obs_2018041500_s.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33b57d78d519a53814d6aa008eaf9564e3e9ec00ace742395100e28506840cf7
-size 58284
+oid sha256:b5dbd1e1ea1a7da581a9110282a2358862e00d0fb0a1fa9d7195294098df1584
+size 65408

--- a/testinput_tier_1/aod_viirs_obs_2018041500_sf42.nc4
+++ b/testinput_tier_1/aod_viirs_obs_2018041500_sf42.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a097a03c2d96e199902bc78c1c354dbda3e1acca8532c451608e7deb7f2cb32
-size 44527
+oid sha256:e86d3204a6bb77a6094c103aefa610c40f92dbf67abbfba70471a34d3c14bfe3
+size 50908

--- a/testinput_tier_1/aod_viirs_obs_2018041500_sf6.nc4
+++ b/testinput_tier_1/aod_viirs_obs_2018041500_sf6.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe1cb4ecfc2afba54a32a8770c81981e96f3512f43ad23e91d0d86fe4a29322f
-size 41623
+oid sha256:a892c9b25ccc3fdb49781bd1f3fea93586ecd065cb3527bc9d9a0566f2d72532
+size 49303


### PR DESCRIPTION
## Description

Here all AOD files are regenerated with the upgrader version https://github.com/JCSDA-internal/ioda/pull/264.
The new files have 2D variables.
Note: I have not regenerated any other files.

## Acceptance Criteria (Definition of Done)

With this ufo-data branch, https://github.com/JCSDA-internal/ioda/pull/262 ioda branch and feature/ioda-v2 ufo branch, all tests should pass in ufo.

## Dependencies

Can't be merged before corresponding ioda PR is approved (in case changes will be needed in the upgrader):
- [ ] waiting on https://github.com/JCSDA-internal/ioda/pull/264