### PR TITLE
Change MDI to underscores

### DIFF
--- a/testinput_tier_1/met_office_profile_consistency_checks_unittests_vertaverage.nc4
+++ b/testinput_tier_1/met_office_profile_consistency_checks_unittests_vertaverage.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5d788f72ca2ab2dbef881a90d2f589821b802ec17dab1d8bf3f84ee4a9f5750
-size 225858
+oid sha256:fa62e4ff36c6deb11a892ab6d3f192b87b77fecd4eca6c048b01d5dd900efe2f
+size 218057

--- a/testinput_tier_1/met_office_profile_consistency_checks_unittests_vertaverage_ascending.nc4
+++ b/testinput_tier_1/met_office_profile_consistency_checks_unittests_vertaverage_ascending.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a6b4df0301c68f48f10c15d7d08a4173b81d50d2920f0df4022b537dec6c7b0
-size 19850
+oid sha256:10a9c81d7050cdbf2e41dfc2bec56a9f7416c53d6fbce4b076213c3651ef878a
+size 20241


### PR DESCRIPTION
## Description

Fixes issue in comparefloat.h in oops which is comparing to similar values as true when the difference is above maxUlpsDiff.
This change in ufo-data is to remove the MDI's present in two nc4 files which are of low precision and appear as actual values in the tests and therefore fail with the new oops changes. This is to replace those with an underscore in the netcdf files.

### Issue(s) addressed

- fixes https://github.com/JCSDA-internal/oops/issues/1222

## Acceptance Criteria (Definition of Done)

New data along with oops changes allows the two tests to pass.
1123 - test_ufo_profileconsistencychecks_unittests_vertaverage (Failed)
1124 - test_ufo_profileconsistencychecks_unittests_vertaverage_ascending (Failed)

## Dependencies

Waiting on the following PRs:
- [ ] waiting on https://github.com/JCSDA-internal/oops/pull/1231
- [ ] waiting on https://github.com/JCSDA-internal/ioda/pull/280

## Test Data
[met_office_profile_consistency_checks_unittests_vertaverage.nc4.gz](https://github.com/JCSDA-internal/ufo-data/files/6554064/met_office_profile_consistency_checks_unittests_vertaverage.nc4.gz)
[met_office_profile_consistency_checks_unittests_vertaverage_ascending.nc4.gz](https://github.com/JCSDA-internal/ufo-data/files/6554065/met_office_profile_consistency_checks_unittests_vertaverage_ascending.nc4.gz)

- [ ] met_office_profile_consistency_checks_unittests_vertaverage_ascending.nc4 
- [ ] met_office_profile_consistency_checks_unittests_vertaverage.nc4