### PR TITLE
New additional test files, 2020121500, for sfc/sonde data - needed for composite obs-operator tests

### DIFF
--- a/testinput_tier_1/sfc_geoval_2020121500_s.nc
+++ b/testinput_tier_1/sfc_geoval_2020121500_s.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4334fa6bd6f0ab480e756231d3e02398f37ceadf1125589a0ad1b9de570e9eb8
+size 444050

--- a/testinput_tier_1/sfc_obs_2020121500_s.nc
+++ b/testinput_tier_1/sfc_obs_2020121500_s.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adc89c5df86b397d0dfa778ee23340624d489abdc47659a3d26fdafef6deddb0
+size 265866

--- a/testinput_tier_1/sondes_geoval_2020121500_s.nc
+++ b/testinput_tier_1/sondes_geoval_2020121500_s.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a534a4870db006c2f4a8ddd75f782312fa53304f3635c52c21a574ec015d0b45
+size 900110

--- a/testinput_tier_1/sondes_obs_2020121500_s.nc
+++ b/testinput_tier_1/sondes_obs_2020121500_s.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:307a935582c11b4f748feafe2151d613a7d8154043b0f1e113e94b49ec701e0f
+size 270455


### PR DESCRIPTION
These are new test obs and geovals files for surface and sonde data used when developing new UFO capability of "composite obs operator" of combining the VertInterp and SfcPCorrected for sonde data and combining the SfcPCorrected and GSISfcModel operators for surface data.

These new files were subsetted from the full global files provided by Cory Martin via GSI Observer.  These files are needed for the ctests added in the related UFO PR.
