### PR TITLE
Add refractivity observations and geovals for Met Office operator

### DIFF
--- a/testinput_tier_1/gnssro_geoval_2019123006_refractivity.nc4
+++ b/testinput_tier_1/gnssro_geoval_2019123006_refractivity.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b3e4cfd3241593d2605c7f810a1366b401f27151a75f09fc2bb29b32829579f
+size 1066376

--- a/testinput_tier_1/gnssro_geoval_2019123006_refractivity_nopseudo.nc4
+++ b/testinput_tier_1/gnssro_geoval_2019123006_refractivity_nopseudo.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:799d6b711284184ada1f65790d950c2cc7173bf4601afdb57f28d68f583be180
+size 1066384

--- a/testinput_tier_1/gnssro_obs_2019123006_refractivity.nc4
+++ b/testinput_tier_1/gnssro_obs_2019123006_refractivity.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95e76285239374538f95f953a7f3ec7ad84037eb6bc38f4b1954ef081bafb853
+size 49030

--- a/testinput_tier_1/gnssro_obs_2019123006_refractivity_nopseudo.nc4
+++ b/testinput_tier_1/gnssro_obs_2019123006_refractivity_nopseudo.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25e4f790cb8057851f3a4c42168ac2ffd676210ef1d3a1087e26ff1a0f60298a
+size 48990


### PR DESCRIPTION
## Description

This adds the data files required by https://github.com/JCSDA-internal/ufo/pull/1171

They are GNSS-RO refractivity observations, and HofX values produced by the Met Office system.  They are IODA-v2 compliant.