### PR TITLE
Correct datetimes in variable_assignment_testdata.nc

### DIFF
--- a/testinput_tier_1/drawvaluefromfile_simple.csv
+++ b/testinput_tier_1/drawvaluefromfile_simple.csv
@@ -1,0 +1,7 @@
+string_variable_1@MetaData,int_variable_1@MetaData,latitude@MetaData,longitude@MetaData,result@IntResult,result@StringResult
+string,int,float,float,int,string
+ABC,1,-2.5,11.25,1,ABC
+_,2,2.4,15.7,75,XYZ
+PQR,4,100,100,75,XYZ
+MNO,5,2.5,15.75,5,MNO
+

--- a/testinput_tier_1/drawvaluefromfile_simple.nc
+++ b/testinput_tier_1/drawvaluefromfile_simple.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b82a68df04ab8dcbbcf29b6f8bbbf74f73f0ab3388b5c7f7f1fe941af2f4ffa6
+size 7399

--- a/testinput_tier_1/obserror_4d.nc
+++ b/testinput_tier_1/obserror_4d.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abefd7e7c9d2c9207b755df83c4e7f2821269024237797bee1c8ea4e06752dc8
+size 7575

--- a/testinput_tier_1/obserror_empty_data_line.csv
+++ b/testinput_tier_1/obserror_empty_data_line.csv
@@ -1,0 +1,3 @@
+StringVar@MetaData,air_pressure@MetaData,longitude@MetaData,air_temperature@ErrorVariance
+string,int,float,float
+

--- a/testinput_tier_1/obserror_misspelled_variance.nc
+++ b/testinput_tier_1/obserror_misspelled_variance.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcb3fc8be2a9e10abe6f42592a2bea0a8f0b967e5124c2bd41f1dcb1e2486799
+size 6240

--- a/testinput_tier_1/obserror_multiple_variances.nc
+++ b/testinput_tier_1/obserror_multiple_variances.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4860f895f87a3e6981cc0bf170b78d4036976b46e6f82c5fc9ff3b4b2d2e0d8c
+size 6802

--- a/testinput_tier_1/variable_assignment_testdata.nc
+++ b/testinput_tier_1/variable_assignment_testdata.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bd9933f27197f5f2b1ddb6ae1436058b3b5d12e07a31c3e8605ac59313ca6ac
-size 56575
+oid sha256:4a2e7ad97e3ea6fcb63e667358883f75fefcbe02ccc234cd17fe90045ae28b12
+size 19038

--- a/testinput_tier_1/variable_assignment_testdata.nc
+++ b/testinput_tier_1/variable_assignment_testdata.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5bc3e3ebc9ffc200f0bc8991f6fc7818f051e1db251444f57e90ca39fd8a284
+oid sha256:9bd9933f27197f5f2b1ddb6ae1436058b3b5d12e07a31c3e8605ac59313ca6ac
 size 56575


### PR DESCRIPTION
## Description

In some strings in this file, dates were separated from times with `@`'s instead of `T`'s.
### Issue(s) addressed

Needed by https://github.com/JCSDA-internal/ufo/pull/1280.

## Dependencies

None

## Impact

None

## Test Data

None