### PR TITLE
Assimilation of derived variables

### DIFF
--- a/testinput_tier_1/variable_assignment_testdata.nc
+++ b/testinput_tier_1/variable_assignment_testdata.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb9fe8f17818d1260f30f520f84686eeee0977c4fc8711fc9e5f06cc275f0d01
-size 18316
+oid sha256:4a2e7ad97e3ea6fcb63e667358883f75fefcbe02ccc234cd17fe90045ae28b12
+size 19038


### PR DESCRIPTION
## Description

This PR extends the variable_assignment_testdata.nc file with a new variable, `surface_pressure`, containing some missing values both in the `ObsValue` and `ObsError` groups (at non-overlapping locations). This is needed by tests added in https://github.com/JCSDA-internal/ufo/pull/1304.

To avoid future merge conflicts, this PR is based on the branch of https://github.com/JCSDA-internal/ufo-data/pull/18.

### Issue(s) addressed

Contributes to JCSDA-internal/ufo#1187

## Dependencies

Waiting on the following PRs:
- [ ] waiting on https://github.com/JCSDA-internal/ufo-data/pull/18

## Impact

None