### PR TITLE
Add a file needed by the tests of the SolarZenith function

### DIFF
--- a/testinput_tier_1/solar_zenith.nc4
+++ b/testinput_tier_1/solar_zenith.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d19ce397255448005d2c624ec92e0df998b47afd1729971fb5ac86d8a6471540
+size 92162


### PR DESCRIPTION
## Description

This PR adds a file used by tests of the newly added SolarZenith function. It is needed by https://github.com/JCSDA-internal/ufo/pull/1442.

The file was generated by postprocessing the output of the `OpsProg_TestSolarZenith` program available on the `dev/wojciechsmigaj/r14764_2613_solar_zenith` branch of OPS. The program produced a NetCDF file; this was converted into a ioda-v2 file, loaded into ioda and saved immediately to convert time offsets into datetime strings. Then the file was edited manually by replacing a small number of values by missing values or values outside the range of validity. (All non-missing values in the variables from the `TestReference` group were produced by `Ops_Solar_Zenith` and weren't modified in any way except for a double-to-float conversion.)
 
### Issue(s) addressed

None

## Dependencies

None

## Impact

None