### PR TITLE
Files for new History Check test

### DIFF
--- a/testinput_tier_1/met_office_history_check.nc4
+++ b/testinput_tier_1/met_office_history_check.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c37ae830632b511994c4bd804524ad68bdb1c1d88d644763132142cb564dde33
+size 18660

--- a/testinput_tier_1/met_office_history_check_wide.nc4
+++ b/testinput_tier_1/met_office_history_check_wide.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b5743d6b38ef2782b1c6a55405bf325d5e9062ed58b7850d60b572d8b20b403
+size 18660


### PR DESCRIPTION
Add files for new History Check tests that use test_ObsFilters.x. These files contain data for both the standard and the wider ObsSpaces that are used in the history check. There are two synthetic profiles in each case.