### PR TITLE
Reverse order of geovals for profile QC code

### DIFF
--- a/testinput_tier_1/met_office_conventional_profile_processing_profileaverageobs_geovals.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_profileaverageobs_geovals.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a59d2812c10c6a796d6d1370488ed470eb3575111fe47c40ad0a1f932357544
-size 98555
+oid sha256:047cb4f74669ecc87ebde9503af67dc02ab904a3fa0d2e0a6ae43887ad465fe1
+size 98496

--- a/testinput_tier_1/met_office_conventional_profile_processing_profileaverageobs_geovals_reversed.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_profileaverageobs_geovals_reversed.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a26d6d904f9e7b2fe29ccbd2cd164efadac4f7589cacf09fce9016d6e22fa91c
+size 98496

--- a/testinput_tier_1/met_office_conventional_profile_processing_unittests_vertinterp_geovals_reversed.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_unittests_vertinterp_geovals_reversed.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfc4cccbb9bdbc4d81b50edabf68335f9b97418fa1e80e3ecce5a19aa30c47ee
+size 25288


### PR DESCRIPTION
Reverse order of geovals for ProfileAverage obs function. Also add a 'reversed' version (in which the GeoVaLs go from bottom to top) in order to trigger an exception.

Please merge at the same time as JCSDA-internal/ufo#1831