### PR TITLE
Flipping geovals direction for Ground Based GNSS

### DIFF
--- a/testinput_tier_1/groundgnss_geovalsreverse_20191230T0600Z.nc4
+++ b/testinput_tier_1/groundgnss_geovalsreverse_20191230T0600Z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dade4e38ed59e49b2d86ca3e2b06ef1d42a75c44a506d2e39b69b59b215cbc3
+size 43528


### PR DESCRIPTION
## Description

Flipping the direction of the data files for the Met Office Ground Based GNSS data files. This is required as the new convention is for geovals to be top to bottom and the current data is bottom to top. 


### Issue(s) addressed

Link the issues to be closed with this PR


## Acceptance Criteria (Definition of Done)

New data files merged with code changes

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- [ ] waiting on https://github.com/JCSDA-internal/ufo/pull/1850

## Impact

None
