### PR TITLE
addition of surface_pressure_obserror TestReference

### DIFF
--- a/testinput_tier_1/sfc_obs_2018041500_metars_small.nc
+++ b/testinput_tier_1/sfc_obs_2018041500_metars_small.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b35798c18ae43543e14894c5c750b9206b5a3dc590f87ada25a5652d25505b9e
-size 82468
+oid sha256:aff5ccfadb71fa886f7616dc2de9cd36ce0e42b2ae37e5e66824cc3d4de3c48b
+size 32712


### PR DESCRIPTION
## Description

This PR updates the data file with a new TestReference/surface_pressure_obserror vector of 33 values for the purpose of the corresponding unit test in UFO, which is found in
[UFO PR1856](https://github.com/JCSDA-internal/ufo/pull/1856)

### Issue(s) addressed

The above-mentioned PR contains a UFO issue that this helps resolve along with the updated data file.

## Acceptance Criteria (Definition of Done)

All tests pass.

## Dependencies

Mentioned above in the description, this file update makes it possible to run the new test in UFO.

## Impact

No impacts to other repos.
