### PR TITLE
renamed adt, subsampled adt nc files

### DIFF
--- a/testinput_tier_1/Jason-2-2018-04-15.nc
+++ b/testinput_tier_1/Jason-2-2018-04-15.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de5ddadda53fb30958a5109d6668adaa3d4681452eb962ac23fd34bcd4967f5a
-size 2014931
+oid sha256:78052bdec5ec2cbf2815c66b6ec639da81d987a87fdf0004c01aa965577a93b9
+size 12977

--- a/testinput_tier_1/Jason-2-2018-04-15_geovals.nc
+++ b/testinput_tier_1/Jason-2-2018-04-15_geovals.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5eb1af40673c10a5705403a23beeb9650ce0fea1f6f848ee0a5cbb258de3576
-size 4498092
+oid sha256:6a6bc54d1337934dce5448015f0b8b41926cdbc873a5c66cab8cbda714a9fa30
+size 5116


### PR DESCRIPTION
## Description
This PR does 2 things:
- Renaming of **obs_absolute_dynamic_topography** to **absolute_dynamic_topography** in the altimetry files (Jason*.nc)
- Sub-sampling of the original files to speed-up the tests

### Issue(s) addressed
- fixes [#1875](https://github.com/JCSDA-internal/ufo/issues/1875)

## Dependencies

Waiting on the following PRs:
- [ ] waiting on [ufo #1876](https://github.com/JCSDA-internal/ufo/pull/1876)

