### PR TITLE
Adding MOPITT CO test files for UFO test

### DIFF
--- a/testinput_tier_1/mopitt_co_2020090318_m.nc4
+++ b/testinput_tier_1/mopitt_co_2020090318_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5062e15861e3cc5e25cb71068c5ff537c302900ce66fcede5cd0904cf840747
+size 3416873

--- a/testinput_tier_1/mopitt_co_geoval_2020090318_m.nc4
+++ b/testinput_tier_1/mopitt_co_geoval_2020090318_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bded1f40320c6a318ba327ef0afabe15c68a2e4cba3e4cc8ebc6bddb0d7eddff
+size 2487449


### PR DESCRIPTION
## Description

Adding MOPITT CO test files for UFO test.

Geovals were derived from the lam cmaq file that is already in the fv3-jedi-data files. 
OmF show significant differences. It could be updated in the future with a better quality model field maybe.

### Issue(s) addressed

[JCSDA-internal/ufo#1779](https://github.com/JCSDA-internal/ufo/issues/1779)
[JCSDA-internal/ioda-converters#733](https://github.com/JCSDA-internal/ioda-converters/issues/733)
JCSDA-internal/ioda#570

## Dependencies

ufo
ufo-data

## Impact


