### PR TITLE
test data for Ocean Pressure to Depth ObsFunction

### DIFF
--- a/testinput_tier_1/ocean_pressure_depth_testdata.nc4
+++ b/testinput_tier_1/ocean_pressure_depth_testdata.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56301dd7c876f6a075cbe4c85cbbbbfdc3d927f9ea85258d14e007bfc24f36eb
+size 91656

--- a/testinput_tier_1/ocean_pressure_depth_testdata.nc4
+++ b/testinput_tier_1/ocean_pressure_depth_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56301dd7c876f6a075cbe4c85cbbbbfdc3d927f9ea85258d14e007bfc24f36eb
-size 91656
+oid sha256:8692b6deb147e3e703922329b2f7a5702f8c9805a4951d23456c30aa8bbb33ad
+size 17032

--- a/testinput_tier_1/ocean_pressure_depth_testdata.nc4
+++ b/testinput_tier_1/ocean_pressure_depth_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8692b6deb147e3e703922329b2f7a5702f8c9805a4951d23456c30aa8bbb33ad
-size 17032
+oid sha256:21a780d703cef7eb16b014809f6f1c8a8cf16e83daa906a61f75b9786e8e47af
+size 16814


### PR DESCRIPTION
## Description

Test data for JCSDA-internal/ufo/pull/1895 which converts pressure (Pa) to depth (m). The data were obtained from the OPS for 2 Argo locations (one close to the equator, one further away, since the conversion depends on latitude), and 50 levels were selected from each (spread out from surface to depth). The pressure before conversion and depth after conversion (for test reference) were both obtained from the OPS run. One of the pressure levels has been set to missing, to test that the resultant depth is also missing. The ObsError on a different level was set to missing, to show that it does not affect the conversion, as long as the pressure value is non-missing.

### Issue(s) addressed

- contributes to https://github.com/JCSDA-internal/ufo/issues/1888

## Acceptance Criteria (Definition of Done)

The ctest for this ObsFunction should pass.

## Dependencies

Please merge the corresponding ufo PR after this one.
- [ ] waiting on JCSDA-internal/ufo/pull/1895

## Impact
JCSDA-internal/ufo/pull/1895
