### PR TITLE
Add onedvar test that stores transmittance

### DIFF
--- a/testinput_tier_1/geovals_atovs_transmittance_20210701T1200Z.nc4
+++ b/testinput_tier_1/geovals_atovs_transmittance_20210701T1200Z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:173482ccedf1b4ffe557868bbc446b21f0981951ff3411413d3bde39080ec793
+size 363883

--- a/testinput_tier_1/obs_atovs_transmittance_20210701T1200Z.nc4
+++ b/testinput_tier_1/obs_atovs_transmittance_20210701T1200Z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d6b02ace4727d4a7a07cabe5cecb7d720b22723426867c573c08bc6e11c1961
+size 110938

--- a/testinput_tier_1/obs_atovs_transmittance_20210701T1200Z.nc4
+++ b/testinput_tier_1/obs_atovs_transmittance_20210701T1200Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d6b02ace4727d4a7a07cabe5cecb7d720b22723426867c573c08bc6e11c1961
-size 110938
+oid sha256:1446fc5ab5db384abb8c6df5626239342f3b9d3d6fcd8d98f97a06c84016ee7e
+size 82068


### PR DESCRIPTION
## Description

This change adds the necessary input files for testing the creation and storage of the surface to space transmittance , computed for each channel at the end of OneDVar

This is linked to ufo issue https://github.com/JCSDA-internal/ufo/issues/1943


## Acceptance Criteria (Definition of Done)

The new files are successfully used in ufo ctest _test_ufo_atovs_rttovonedvar_transmittance_

## Dependencies

This PR is required for successful completion of ufo PR https://github.com/JCSDA-internal/ufo/pull/1969

## Impact

None expected