### PR TITLE
RTTOV Fortran interface: fix a bug found for large datasets.

### DIFF
--- a/testinput_tier_1/atms_n20_obs_2020040100_allsurfacetypes.nc4
+++ b/testinput_tier_1/atms_n20_obs_2020040100_allsurfacetypes.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdef44328de0668d88a5431c0ce5180ca24f1200ad9085778ed5a29705fed7cc
+size 22949

--- a/testinput_tier_1/geovals_atms_20200401T0000Z_allsurfacetypes.nc4
+++ b/testinput_tier_1/geovals_atms_20200401T0000Z_allsurfacetypes.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e16b408dde6b8498b23f8fdd7ffeaec24e948a626d70d9c93a829c1da1e56f9
+size 100278


### PR DESCRIPTION
## Description

Data files are added to test a bug in the emissivity initialisation for large datasets.  This is caused by the memory being allocated up to the maximum batch size (default 10000 channels).  The calcemiss is initialised to false and if sea is encountered this gets switched to true.  However when the second and sebsequent batches are called the calcemiss flag is not reset to the default value and so the true persists and can be used with a land profile.

This test data is needed because the current RTTOV test data either has all sea pixels or land and seaice and the issue described above is never activated.  A large test with atms data has highlighted this bug.

The datafiles added here contain surface types over sea, land and seaice.

## Acceptance Criteria (Definition of Done)

All ctests passing.

## Dependencies

As this is new data there is no dependency on this being merged but this merge should be done before the associated ufo PR which will have this PR as a dependency. 

## Impact

None