### PR TITLE
Modifications to present post filters acting on non-simulated variables

### DIFF
--- a/testinput_tier_1/filters_testdata.nc4
+++ b/testinput_tier_1/filters_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f65fc2986e55268d0f5beb8e1ee7f8feb25b088559ba96c9bbe6cf634c037199
-size 93186
+oid sha256:645ac03be99ba067044cd4ad6f4e83ab75ebf80b12184f453a32cd0ef2a6c29c
+size 266135


### PR DESCRIPTION
Modifications to present post filters acting on non-simulated variables. This PR adds a Variable4 (but not an associated HofX) to the data file and is required for  [JCSDA-internal/ufo#1997](https://github.com/JCSDA-internal/ufo/pull/1997). 