### PR TITLE
Workaround for obs_bias_readwrite and obs_bias_covariance_details test failures on RedHat 8

### DIFF
--- a/testinput_tier_1/satbias_amsua_n19_test1.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test1.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caa300928821bc55921f39d50eb61a4e61a914c77e6d72763e3d9590763fec9c
+size 8985

--- a/testinput_tier_1/satbias_amsua_n19_test2.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test2.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71ea0f9a3832335be7621280304797d51e3abb7882ed54a3349fdea9995d3361
+size 8985

--- a/testinput_tier_1/satbias_amsua_n19_test3.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test3.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ea6d4d670d40a28868ff1382fd68e3c2bdfa2303cf80443371347d7b10555a8
+size 8985

--- a/testinput_tier_1/satbias_amsua_n19_test4.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test4.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83b04411f3f648989e71727e4283428556eddb86d9da81201840acf2ae12b54
+size 8985

--- a/testinput_tier_1/satbias_amsua_n19_test5.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test5.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2096a0501291fcb455c015eef13837ebbd2eb6545ea9b57844e27d0728549d27
+size 8985

--- a/testinput_tier_1/satbias_amsua_n19_test6.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test6.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8f4a827d12d668aa26c0fc4500e17d3e869f801d34f3356ad20142d56525e68
+size 8985

--- a/testinput_tier_1/test_cov_satbias_amsua_n19.nc4
+++ b/testinput_tier_1/test_cov_satbias_amsua_n19.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:563a4ce2d684c01dbd56b904ea6148c80967c03e6bf93de9050dc7d915eecdaa
+size 9449


### PR DESCRIPTION
## Description

This PR provides a workaround for the `test_ufo_obs_bias_readwrite` and `test_ufo_obs_bias_covariance_details` test failures on the AWS RedHat 8 instance. These tests complete and reports a status of zero, but then they crashes as the objects are destructed. This is happening with a known issue in the hdf5 library where closing a file sometimes gets mishandled when there are multiple file handles pointing to a single file.

The workaround in this case is to place copies of the expected output files in ufo-data and have the step that reads the file (ObsBias and ObsBiasCovariance constructors) read the separate files in ufo-data.  This creates the situation where only one file handle is pointing to each file.

I am proposing this workaround because this provides a timely fix for the upcoming release, and up to this point this test is the only situation where a single process has a bias file open with multiple file handles. In the DA flows this situation does not occur.

This issue needs to be addressed eventually, but that can be done after the release.

### Issue(s) addressed

- fixes  jcsda-internal/fv3-bundle/issues/82

## Acceptance Criteria (Definition of Done)

All fv3-bundle tests pass on AWS RedHat 8 instance.

## Dependencies

- [ ] merge with jcsda-internal/ufo/pull/2075

## Impact

None