### PR TITLE
Remove Larger files present in testinput_tier_1 that are not used (891Mb)

### DIFF
--- a/testinput_tier_1/airs_aqua_obsdiag_2018041500_m_qc.nc4
+++ b/testinput_tier_1/airs_aqua_obsdiag_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7200f0857607d706eda8e0bc3de0a5786277e40c741aff7af60be07ac700acf9
-size 72818504

--- a/testinput_tier_1/cris-fsr_npp_obsdiag_2018041500_m_qc.nc4
+++ b/testinput_tier_1/cris-fsr_npp_obsdiag_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6506ccd0b8e7113fd4669c61890fcd926199fd1253bef21da931bd5f2a482cc9
-size 141044842

--- a/testinput_tier_1/cris-fsr_npp_obsdiag_2018041500_s_qc.nc4
+++ b/testinput_tier_1/cris-fsr_npp_obsdiag_2018041500_s_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d535252ae2241742ce2cce6bbd4c97bd87e30456d0cbcd6f4753c35dc83d820a
-size 12914578

--- a/testinput_tier_1/iasi_metop-a_obsdiag_2018041500_m.nc4
+++ b/testinput_tier_1/iasi_metop-a_obsdiag_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6bd64844e08329b0926d2d14fbc388eb55c37301b5790a1173c946a649703b7
-size 197040932

--- a/testinput_tier_1/iasi_metop-a_obsdiag_2018041500_m_qc.nc4
+++ b/testinput_tier_1/iasi_metop-a_obsdiag_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:000b9ee449888f335a156bc8a751df817a625583ea806db53c9b08d7c73cb7ab
-size 197040932

--- a/testinput_tier_1/iasi_metop-b_obsdiag_2018041500_m_qc.nc4
+++ b/testinput_tier_1/iasi_metop-b_obsdiag_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:647cb47362686d512f23b4a0c0c6e047fb19d4ae885617a7040e7ad69659062b
-size 197040932

--- a/testinput_tier_1/iasi_metop-b_obsdiag_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/iasi_metop-b_obsdiag_2018041500_m_unittest.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:883aed654fd1a0b5d0100b6f0b1cffd6377757f2dc0830eebfa57c3ce74f2160
-size 115979462


### PR DESCRIPTION

This PR has for objective to clean-up the `testinput_tier_1` directory of the larger (>10Mb) unused test data files. 

7 Files were identified and deleted:

```
188M    iasi_metop-b_obsdiag_2018041500_m_qc.nc4
188M    iasi_metop-a_obsdiag_2018041500_m_qc.nc4
188M    iasi_metop-a_obsdiag_2018041500_m.nc4
135M    cris-fsr_npp_obsdiag_2018041500_m_qc.nc4
111M    iasi_metop-b_obsdiag_2018041500_m_unittest.nc4
70M     airs_aqua_obsdiag_2018041500_m_qc.nc4
13M     cris-fsr_npp_obsdiag_2018041500_s_qc.nc4
```

There's no dependency with this pull request. 

See issue issue UFO [#2052](https://github.com/JCSDA-internal/ufo/issues/2052) for details.