### PR TITLE
restore 'cris-fsr_npp_obs_2018041500_m.nc4' for mpas-jedi ctest

### DIFF
--- a/testinput_tier_1/cris-fsr_npp_obs_2018041500_m.nc4
+++ b/testinput_tier_1/cris-fsr_npp_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13bfc1d07c0cbbe5a9ff11070628586ec78acebe4e9b9e3cec1ee96cfd039dd5
+size 568202


### PR DESCRIPTION
## Description

MPAS-JEDI develop branch broke after #183, due to the deleted file  `testinput_tier_1/cris-fsr_npp_obs_2018041500_m.nc4`.
After reinstallation, the two ctest failures in mpas-jedi are resolves.

1/1 Test 12: test_mpasjedi_hofx3d .............   Passed    8.12 sec
1/1 Test 14: test_mpasjedi_hofx ...............   Passed   27.73 sec

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes JCSDA-internal/mpas-jedi#748
- addresses post-merge-request to #183 

## Impact
None except MPAS-JEDI

## File reinstalled
    testinput_tier_1/cris-fsr_npp_obs_2018041500_m.nc4