### PR TITLE
Add TestReference/scene_dependent_errors

### DIFF
--- a/testinput_tier_1/atovs_metopb_obs_2021011512_rttov_scatt_add.nc4
+++ b/testinput_tier_1/atovs_metopb_obs_2021011512_rttov_scatt_add.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2a640bb432c1d7d7658bcac76cf213eed8bd740708fece98cd7c4187004e55b
-size 3629234
+oid sha256:90f77bbf3e36bb8ec2c18b9a58f707d8d93c4a4158f15a7dc1c849453da90796
+size 4517298


### PR DESCRIPTION
## Description

Adds variable `TestReference/scene_dependent_errors` to ATOVS test obs file used when running the ufo ctest `ufo_test_tier1_test_ufo_atovs_scenedeperrors`.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

Associated ufo ctest passes successfully.

## Dependencies

Associated PR in ufo:
https://github.com/JCSDA-internal/ufo/pull/2122

## Impact

Affects only:

- [ ] ufo
