### PR TITLE
CloudFirstGuessMinimumResidual: update the iasi test for bugfix

### DIFF
--- a/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
+++ b/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5480f0a62f863c69ee0a08e787ecc94b3880d338f690c014b0640043f718e7fd
-size 51634
+oid sha256:4694ca88b5bc563b1b200e616438a2f9275772a9ab40f9e789c2a2c0ee9b589a
+size 53984


### PR DESCRIPTION
## Description

The iasi test file is updated to change one of the ObsError variables to the missing data indicator in order to test the change.  This has the impact that there is additional missing observation in the 1dvar tests as well.

### Issue(s) addressed

No specific PR issue found when testing IASI porting from the Met Office OPS system to JEDI.

## Acceptance Criteria (Definition of Done)

All ufo ctests passing

## Dependencies

To be merged with the associated ufo change
- [https://github.com/JCSDA-internal/ufo/pull/2248] waiting on JCSDA-internal/ufo/pull/2248

## Impact

None