### PR TITLE
RTTOVOneDVarCheck: Update the iasi rttov test file so that ctp is in Pa not hPa

### DIFF
--- a/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
+++ b/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4694ca88b5bc563b1b200e616438a2f9275772a9ab40f9e789c2a2c0ee9b589a
-size 53984
+oid sha256:db4d6a5ba4aa5371045ebb9e1a73f5b1ca9cc144239acd14f23a04fc8cadd9af
+size 51160


### PR DESCRIPTION
## Description

The cloud top pressure in the 1D-Var is passed around in units of hPa.  The SI unit for pressure is Pa and thus the test file is changed to the SI unit.  This is need for the linked ufo PR .

## Acceptance Criteria (Definition of Done)

All ufo ctests passing.

## Dependencies

To be merged with:
- [JCSDA-internal/ufo/pull/2261](https://github.com/JCSDA-internal/ufo/pull/2260)
