### PR TITLE
Test data for Buddy Check changes (2 length scales and anisotropy)

### DIFF
--- a/testinput_tier_1/met_office_buddy_check_oceanprofile.nc4
+++ b/testinput_tier_1/met_office_buddy_check_oceanprofile.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:100656037e856eb4b7a224e32f98c0b2df95a2ba35e6bcba63a1d2865076bcfd
+size 92029

--- a/testinput_tier_1/met_office_buddy_check_oceanprofile.nc4
+++ b/testinput_tier_1/met_office_buddy_check_oceanprofile.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:100656037e856eb4b7a224e32f98c0b2df95a2ba35e6bcba63a1d2865076bcfd
-size 92029
+oid sha256:2d57a697fa74f4564091a22779f2b4c3cfe5b816828ec30747d01ac03b9b76ad
+size 51393

--- a/testinput_tier_1/met_office_buddy_check_oceanprofile.nc4
+++ b/testinput_tier_1/met_office_buddy_check_oceanprofile.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d57a697fa74f4564091a22779f2b4c3cfe5b816828ec30747d01ac03b9b76ad
-size 51393
+oid sha256:1ba5781c97b915f4cb587ae9376317d57f149e6a4d1715cbdb33f1818fb2d79d
+size 20916


### PR DESCRIPTION
## Description

Met Office Buddy Check modifies the probability of gross error (PGE) of observations according to how close the values are to nearby observations (buddies). The closer the buddies are in space, the closer the (obs and BG) values are expected to be, such that a greater difference in values would increase PGE more (and a really good match can decrease PGE).

For ocean profiles, there are 2 length scales: synoptic and mesoscale, i.e. the "expected closeness" of buddy pairs varies at 2 different speeds when they're very close vs. moderately close to each other. The scales both vary with latitude, and come with associated background errors, and anisotropies, i.e. the "expected closeness" of buddy pairs of a given km distance from each other differs depending on whether they lie closer to an east-west line or north-south. (Though the same anisotropy vs. latitude function is used for both synoptic and mesoscale.)

See https://github.com/JCSDA-internal/ufo/pull/2305 for notes on code changes.

### Issue(s) addressed

Associated with https://github.com/JCSDA-internal/ufo/issues/2268

## Acceptance Criteria (Definition of Done)

A test has been added to the end of `ufo_test_tier1_test_ufo_qc_met_office_buddy_check` to test the additional options - these should be backwards-compatible, so all the buddy check ctests (as well as other ufo ctests) should still pass.

The data for the new test (the subject of this PR) consists of five artificial 2-level profiles, each with salinity and temperature values. The first 3 form a cluster (3 buddy pairs) and the last 2 form a separate cluster (1 pair) at a different latitude. The 1st level is missing from the last 2 profiles, so only the 2nd level of them are checked against each other. The values used for anisotropy and correlation length scales are all fake for the purposes of this ctest. The reference post-buddy PGE values were generated by reproducing the OPS calculation in a spreadsheet. (The same spreadsheet was first verified by checking it could reproduce real values from an OPS run, though just a couple of levels/locations).

## Dependencies

Please merge this ufo-data PR once the following ufo PR is fully approved:
- [ ] https://github.com/JCSDA-internal/ufo/pull/2305

## Impact

None.