### PR TITLE
Test data for Copy Flags From Extended To Original Space filter

### DIFF
--- a/testinput_tier_1/function_copybackflags_testdata.nc4
+++ b/testinput_tier_1/function_copybackflags_testdata.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8048921bd2b2f7ad7ae31b616fe51fc22c0422d609ccab711c2d1a4dff6bee0a
+size 14637

--- a/testinput_tier_1/function_copybackflags_testdata.nc4
+++ b/testinput_tier_1/function_copybackflags_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8048921bd2b2f7ad7ae31b616fe51fc22c0422d609ccab711c2d1a4dff6bee0a
-size 14637
+oid sha256:b86f8fee4791cc2c3f8aa232da604e4096ae7a14a1e4d73bb87d3a50055a8fec
+size 14625

--- a/testinput_tier_1/function_copybackflags_testdata.nc4
+++ b/testinput_tier_1/function_copybackflags_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b86f8fee4791cc2c3f8aa232da604e4096ae7a14a1e4d73bb87d3a50055a8fec
-size 14625
+oid sha256:ce991a7d5828932100eb56d2f3894a68503b545efd99f829e1801c2e579cb4ff
+size 15278


### PR DESCRIPTION
## Description

For ocean profiles, we apply some filters to extended-space observations (averaged on to model levels), but write the original observations (on reported levels) to file - therefore we need the flags from extended space to be copied back to the appropriate locations in original space.

https://github.com/JCSDA-internal/ufo/blob/8f6bc64fdb486076e01304c9c7ec49a087efe450/src/ufo/utils/ProfileAverageUtils.cc is used to link the observation and model levels.

### Issue(s) addressed

Associated with: https://github.com/JCSDA-internal/ufo/issues/2297

## Acceptance Criteria (Definition of Done)

Ctests should pass, particularly `ufo_test_tier1_test_ufo_function_copy_between_extended_and_original_space`. The test data that is the subject of this PR consists of 2 profiles, with respectively 13 and 4 observed levels, and 3 model levels. The depths are such that the 1st model level maps to the first 7 obs levels in profile 1, and the first 2 in profile 2; the 2nd model level maps to the next 6 in profile 1, and the next one in profile 2; the 3rd model level has no obs-level equivalents in profile 1, but maps to the final obs level in profile 2. There are 2 diagnostic flags, `flag1` and `flag2` - each with some levels already set and the others unset, so you can see the filter only setting unset obs levels but leaving obs levels unchanged if they're already set.

The first test shows `DiagnosticFlags/flag1/var1` correctly being copied from model levels to obs levels - the 'where' statement does nothing in this case.

The second test shows the same when you list more than one flag as filter variables - all of them are copied from model levels to obs levels, and leave the obs levels unchanged if they're already set.

The third test shows an error being thrown if a filter variable is specified that is not in group `DiagnosticFlags`.

## Dependencies

Waiting on the following PRs:
- [ ] https://github.com/JCSDA-internal/ufo/pull/2263
- [ ] https://github.com/JCSDA-internal/ufo/pull/2337

## Impact

None.