### PR TITLE
sprint: oceanpressuretodepth test-data update

### DIFF
--- a/testinput_tier_1/ocean_pressure_depth_testdata.nc4
+++ b/testinput_tier_1/ocean_pressure_depth_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1e80ecb01b5ce8956f8f30f1ec5bd66abe5b8b32a6ba255794fe03270d111f3
-size 14524
+oid sha256:1553cb1dd33fecd11fd789958d7b09a75cced9378724393d54e11115ced15a51
+size 30303

--- a/testinput_tier_1/ocean_pressure_depth_testdata.nc4
+++ b/testinput_tier_1/ocean_pressure_depth_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21a780d703cef7eb16b014809f6f1c8a8cf16e83daa906a61f75b9786e8e47af
-size 16814
+oid sha256:f1e80ecb01b5ce8956f8f30f1ec5bd66abe5b8b32a6ba255794fe03270d111f3
+size 14524


### PR DESCRIPTION
## Description

Update test data for ocean pressure to depth variable names change.

Now merged into https://github.com/JCSDA-internal/ufo-data/tree/feature/sprint-ioda-converters-mikecooke77-5

## Dependencies

Waiting on the following PRs:
- [x] merge of https://github.com/JCSDA-internal/ufo/pull/2373
