### PR TITLE
Sprint:  First 3 files hand-edited CDL updates

### DIFF
--- a/testinput_tier_1/geos.mhs_metop-b_obs.2020121500_m.nc4
+++ b/testinput_tier_1/geos.mhs_metop-b_obs.2020121500_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:805abf6cbbcf7a5060a66e2e9bf239865e23a5fc79a5de6759c312793afc6775
-size 272005
+oid sha256:6625b4b0c4750c37c97cbc4efa6897f8bec1c76fa315a773476813b1a5c28ad7
+size 98822

--- a/testinput_tier_1/iasi_metop-a_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/iasi_metop-a_obs_2018041500_m_qc.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb35f783c908ee353c7e67df0ea7c5f9adaaaddd1a3740f581a842a1524f3dce
-size 2385686
+oid sha256:0328ce2d5278da0f8fe4bc8326a780daaf11d0ee90eb33a77c27090caaac88d6
+size 1870575

--- a/testinput_tier_1/iasi_metop-a_obs_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/iasi_metop-a_obs_2018041500_m_unittest.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50f71e0c0b78840b778f93d713e39d5b07be1f5288bf67ed9110b1e996fa073c
-size 369722
+oid sha256:6646557df51762009d2debd593182bf5aa052f36a8cae74b8d30941b58a9064d
+size 270736


### PR DESCRIPTION
## Description

As part of naming convention, a series of variables like `MetaData/sensorAzimuthAngle` are expected and hundreds of code and YAML files were updated during a sprint.  Sadly, some of the desired MetaData variables are instead found in the group `VarMetaData` and have dimension `nvars` instead of the new `Channel` variable.  Therefore a bunch of `testinput_tier_1` data files are still not adequate for the code sprint.

Therefore, I have begun to hand-edit `ncdump`-created CDL files to get rid of deprecated dimensions and group names and fix the files to work in the sprint-ioda-converters branch.  This PR addresses only THREE files to begin the work.  Below in the issues addressed section, I describe the steps I used to achieve these sample files.

### Issue(s) addressed

```
# Use ncdump with more precision output (-d option, first value is single- next value is double-precision)

 ncdump -d 9,17 iasi_metop-a_obs_2018041500_m_qc.nc4 > iasi_metop-a_obs_2018041500_m_qc.cdl


# Edit the CDL file to move items out of group VarMetaData and into MetaData.
# Also swap nvars dimension for variables needed to keep into dimension of Channel
# but a few variables with nvars dimension can be eliminated as well.


 vi iasi_metop-a_obs_2018041500_m_qc.cdl

# re-create a new netcdf file using ncgen command
# use ncks to re-compress the data. Pick the Location dimension size in the file for setting the value 100 seen below

 ncgen -k3 -x iasi_metop-a_obs_2018041500_m_qc.cdl -o new.nc4
 ncks --cnk_dmn Location,100 -L 4 new.nc4 new2.nc4
 /bin/mv new2.nc4 iasi_metop-a_obs_2018041500_m_qc.nc4 ; rm new.nc4
```

## Acceptance Criteria (Definition of Done)

Fixing Ctests in ufo `feature/sprint-ioda-converters` branch

## Dependencies

Coming later.

## Impact

None if kept within sprint branch.
