### PR TITLE
SPRINT: update ufo-data for airs-qc-filter test

### DIFF
--- a/testinput_tier_1/airs_aqua_obs_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/airs_aqua_obs_2018041500_m_unittest.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5289a0d7aeee4898bbe345c1b1a3110941ecb1d5d5fab640b8eb23d1a57e7c1e
-size 213928
+oid sha256:ce2e1f462b1c629748eda491a8472dcb8dea21229db329492628dd1edd5dbc94
+size 284557


### PR DESCRIPTION
## Description

Moved some variables needed in the ctest to MetaData instead of using VarMetaData.

This is required by 
[UFO#2478](https://github.com/JCSDA-internal/ufo/pull/2478)


