### PR TITLE
Fix several unit tests

### DIFF
--- a/testinput_tier_1/function_select_testdata.nc4
+++ b/testinput_tier_1/function_select_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d230d1d7f00364e3cc4bf172bb591ba50ed27f8403c6aaf6c57441bcfac6212
-size 52209
+oid sha256:7c8e0dcede75b2bb7d84c57bebf434b486209a9ca34ebd53d84501f4567373f7
+size 54243

--- a/testinput_tier_1/met_office_conventional_profile_processing_rh.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_rh.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ef74ccfcb294b1b93ca72e144c98c5afc11d1f5d398b179dd054859e59ecff5
-size 672901
+oid sha256:9164ffe94c27d9e29174ba5a698946cc8dd4d9478cd1041e9adae52c918e2b18
+size 698996

--- a/testinput_tier_1/radar_rw_obs_2020101300_m.nc4
+++ b/testinput_tier_1/radar_rw_obs_2020101300_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b0bcde808776c7d009c7e5f3261cc6c446bec72bf1397d8bfa8d0eb86199c63
-size 88332
+oid sha256:f0e99e74da390cc6ebd08d9abe63bf30062f09fb6249517f2aaef787711d4cbc
+size 90884


### PR DESCRIPTION
Fix several more unit tests.

The following changes were made to ObsSpace.yaml:

(1) Add the following conversion:
```
  - Variable: [ "radialVelocity", "radial_velocity" ]
```

(2) Add the variable `channelData` (which is just used in unit tests, but had already been converted in the yaml). Note this means "data in multiple channels", not channel number.
```
  - Variable: [ "channelData", "channel_data" ]
    Dimensions: [ [ "Location", "Channel" ] ]
```

Please merge at the same time as JCSDA-internal/ufo#2519
