### PR TITLE
Add options to validator to ignore warnings and/or ignore errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,10 @@ foreach ( f ${OBS_FILES} )
 		COMMAND ioda-validate.x
 		LABELS ufo_data_validate
 		ENVIRONMENT "ECKIT_COLOUR_OUTPUT=1"
-		ARGS "${IODA_YAML_ROOT}/validation/ObsSpace.yaml" "${f}"
+		ARGS "--ignore-warn"
+                     "--ignore-error"
+                     "${IODA_YAML_ROOT}/validation/ObsSpace.yaml"
+                     "${f}"
 		)
 endforeach()
 


### PR DESCRIPTION
## Description

This PR adds the options to the ioda validator command (in ctests) to ignore warnings and errors. See jcsda-internal/ioda/pull/845 for details.

### Issue(s) addressed

-fixes jcsda-internal/ioda/issues/843

## Acceptance Criteria (Definition of Done)

ctests pass.

## Dependencies

- [ ] merge with jcsda-internal/ioda/pull/845
- [ ] merge with jcsda-internal/ioda-converters/pull/1123

## Impact

None
