### PR TITLE
SPRINT: For now have validator ignore warnings and errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,10 @@ foreach ( f ${OBS_FILES} )
 		COMMAND ioda-validate.x
 		LABELS ufo_data_validate
 		ENVIRONMENT "ECKIT_COLOUR_OUTPUT=1"
-		ARGS "${IODA_YAML_ROOT}/validation/ObsSpace.yaml" "${f}"
+		ARGS "--ignore-warn"
+                     "--ignore-error"
+                     "${IODA_YAML_ROOT}/validation/ObsSpace.yaml"
+                     "${f}"
 		)
 endforeach()
 


### PR DESCRIPTION
## Description

This PR adds the options to ignore warnings and errors from the ioda-validator.x app. This is being done to enable a two step process for getting ufo switched over to the new convention names. Step 1 is to get ctests passing using the new names, step 2 is to get all of the test files to pass the ioda validator.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

All validator ctests pass.

## Dependencies

None

## Impact

None
