### PR TITLE
[obs-conventions] Update files for bias tests and tropomi test to conventions

### DIFF
--- a/testinput_tier_1/aircraft_artificial_bias.nc4
+++ b/testinput_tier_1/aircraft_artificial_bias.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4a5ab49398d649ae2125a334f489e445bb826972d947873539b25703ffcad91
-size 7605
+oid sha256:1b291bfec294f6ebdf1a05902fa5ab8d58c560fca7fa39147b5ad06d5b1f2775
+size 7596

--- a/testinput_tier_1/aircraft_artificial_bias_2.nc4
+++ b/testinput_tier_1/aircraft_artificial_bias_2.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:804a05828d84b57cfdbe80b3c1051ff9264d73adf2342c0f9024daec75894623
-size 7605
+oid sha256:1fe661caa4f1e5034bf7ea0b33f3de3cc0a1fafacd24aef485724512ee4b5c9f
+size 7596

--- a/testinput_tier_1/tropomi_co_total_2021081518_m.nc4
+++ b/testinput_tier_1/tropomi_co_total_2021081518_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f849808e207c2fc62ba6c63f986c478d39ffdf52d300f51085c445ae0ecbde6
-size 173772
+oid sha256:e5b39db5b9652f4a847a1cc3630acd32d86fb6144b0d014097f96e95178d44cf
+size 350719


### PR DESCRIPTION
## Description

Updates to fix ufo tests for tropomi and bias correction operator:

- `testinput_tier_1/aircraft_artificial_bias.nc4` and `testinput_tier_1/aircraft_artificial_bias_2.nc4` are changed to specify `variables` for the bias correction coefficients according to OBS convention:
>  variables = "eastward_wind", "northward_wind", "specific_humidity",
    "air_temperature" ;

is changed to
> variables = "windEastward", "windNorthward", "specificHumidity",
    "airTemperature" ;

- `testinput_tier_1/tropomi_co_total_2021081518_m.nc4` is updated to the obs convention by running `ioda-upgrade-v2-to-v3.x`.
