### PR TITLE
Set missing values for ObsError

### DIFF
--- a/testinput_tier_1/oceanprofile_theta_pressure_testdata.nc4
+++ b/testinput_tier_1/oceanprofile_theta_pressure_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0802c504871b6c22a67d373dab284afb8f7ba654eded578459e774c251131edf
-size 82572
+oid sha256:0eed139309f07183bc44df4c38358a2a52a8acf3ed1991633905b1f8d0849cf3
+size 71951


### PR DESCRIPTION
## Description

Set the missing values in the `ObsError` group to match the other groups for the ocean variable transforms test input file.

## Issues addressed

https://github.com/JCSDA-internal/ufo/issues/2678

## Dependencies

Merge along with the following PRs:
- JCSDA-internal/ufo/pull/2664

## Impact

- [ ] ufo

