### PR TITLE
Test file for fill missing derived from original

### DIFF
--- a/testinput_tier_1/wind_unit_transforms_missing_values_2d_2018041500.nc4
+++ b/testinput_tier_1/wind_unit_transforms_missing_values_2d_2018041500.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b940d27416ab2fae27d44ffc06dc30e0bca3d3275f9dc5dace5dcc807eba6cd1
+size 15396


### PR DESCRIPTION
## Description

Data change for https://github.com/JCSDA-internal/ufo/pull/2675. 

The new file is copied from "wind_unit_transforms_missing_values_2018041500.nc4" but modified to have a channels dimension (4 channels in this case).

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

## Acceptance Criteria (Definition of Done)

ufo test passes.

## Dependencies

Needs to be merged with ufo branch
- [ ] waiting on JCSDA-internal/ufo/pull/2675

## Impact

None
