### PR TITLE
Update pressureAtTopOfCloud reference to Pa

### DIFF
--- a/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
+++ b/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74c462fce3c1601b7b5b5d10034bc48dea325756e67518c537f243fbe67bfc05
-size 90126
+oid sha256:21bbf3868ddd3556c254520be4f6b3124695008bddb96d9bf13bf2a7c8ff229c
+size 90159


### PR DESCRIPTION
## Description

The pressure at the top of the cloud should be in Pa not hPa.  This PR changes the `TestReference/pressureAtTopOfCloud` to these units.

### Issue(s) addressed

None specificially raised

## Acceptance Criteria (Definition of Done)

All ctests passing in:
- [ ] https://github.com/JCSDA-internal/ufo/pull/2694

## Dependencies

To be merged with:
- [ ] https://github.com/JCSDA-internal/ufo/pull/2694

## Impact

None outside of ufo.