### PR TITLE
Change ocean profile geovals to include depth variable

### DIFF
--- a/testinput_tier_1/profile_2018-04-15_geovals.nc
+++ b/testinput_tier_1/profile_2018-04-15_geovals.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:089a56d3f331af26f1ee065d4bdd9b6207efdb8f0e6e0ab7c17f3a191292ffe2
-size 717660
+oid sha256:d71d1022699bee2537b050c6c7b4e71ddd27d3d68a9a67ec5e3a8a010160ae7f
+size 949052

--- a/testinput_tier_1/profile_2018-04-15_geovals.nc
+++ b/testinput_tier_1/profile_2018-04-15_geovals.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d71d1022699bee2537b050c6c7b4e71ddd27d3d68a9a67ec5e3a8a010160ae7f
-size 949052
+oid sha256:f86c20c779d76ee30b986f4e082e91858f2ad732f0d953d52799488ca6a1e222
+size 949200


### PR DESCRIPTION
## Description

This PR modifies the testinput_tier_1/profile_2018-04-15_geovals.nc file to include depth in addition to thickness in order to use the VertInterp generic forward operator.

### Issue(s) addressed

No issue created, part of VertInterp code sprint

## Acceptance Criteria (Definition of Done)

Needs to merge in before a forthcoming UFO PR

## Dependencies

None

## Impact

- [ ] ufo will need to be updated after this is merged in

