### PR TITLE
Poisson disk thinning filter OPS compatibility mode option test reference data

### DIFF
--- a/testinput_tier_1/met_office_poisson_disk_thinning_sort.nc4
+++ b/testinput_tier_1/met_office_poisson_disk_thinning_sort.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40ef358736eae3ffd296ff577756fae825f8e002ba31c872e46b36484d985b5b
-size 14103
+oid sha256:8388dbbbb3e14f1b8b1a4d704564b48a0bcc40410ccae65208cd7422d92f0863
+size 14996


### PR DESCRIPTION
## Description

This PR adds test reference data for a compatibility mode option to the Poisson disk thinning filter which allows a closer match to outputs from the legacy Met Office observation processing system.

### Issue(s) addressed

- fixes JCSDA-internal/ufo/issues/2808 

## Acceptance Criteria (Definition of Done)

Ctests added in JCSDA-internal/ufo/pull/2809 pass.

## Dependencies

None.

## Impact

None.