### PR TITLE
Add a data file for obsvalue predictor test

### DIFF
--- a/testinput_tier_1/aod_obs_2018041500_m_predictors.nc4
+++ b/testinput_tier_1/aod_obs_2018041500_m_predictors.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec1aa81e6ba93dc6deee0c9e08d6fa1ada486a81e8dcbaadf78a306c14f33699
+size 78161


### PR DESCRIPTION
## Description

This PR adds data file for related ufo PR https://github.com/JCSDA-internal/ufo/pull/2831. This ufo PR adds an obsvalue predictor for VarBC of Aod obs, and creates a test in ufo.

### Issue(s) addressed

Link the issues to be closed with this PR
- https://github.com/JCSDA-internal/ufo/issues/2830

## Acceptance Criteria (Definition of Done)

The data file is added and passes test.

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
https://github.com/JCSDA-internal/ufo/pull/2831

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)
- [x] ufo
