### PR TITLE
Input files for cloud cost with surface wind

### DIFF
--- a/testinput_tier_1/geovals_gmihigh_20210701T1200Z_out_0000_m.nc4
+++ b/testinput_tier_1/geovals_gmihigh_20210701T1200Z_out_0000_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24a550d69a5bcac62acfb1a6029e4932dd81850cec2023c0fc4081e7f9d5cb99
+size 55857

--- a/testinput_tier_1/jopa_gmihigh_20210701T1200Z_out_m.nc4
+++ b/testinput_tier_1/jopa_gmihigh_20210701T1200Z_out_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f9e0cd58944a7b7a3e8cafa8f77d47f9083fbe298fa30bc1c01a68a166925ee
+size 814322

--- a/testinput_tier_1/jopa_gmihigh_20210701T1200Z_out_m.nc4
+++ b/testinput_tier_1/jopa_gmihigh_20210701T1200Z_out_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f9e0cd58944a7b7a3e8cafa8f77d47f9083fbe298fa30bc1c01a68a166925ee
+oid sha256:ebdb752adc74a50dbdbfe71b3c225a07f5cb3adcd2ae0475a028ab97e7891b5a
 size 814322


### PR DESCRIPTION
## Description

This change adds the input files for testing the calculation of the cloud cost used for quality control when surface winds are also included in the state vector.

## Dependencies

This PR is required by https://github.com/JCSDA-internal/ufo/pull/2851