### PR TITLE
bias interpolation data file follow convention for sensorScanPosition

### DIFF
--- a/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
+++ b/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:faca424037c79e16cc2029e9b2a56049f0d28afba9a52f15d3f02af5b567df2f
+oid sha256:f2b6bd8639ade8872c376690ec4c82d6215a6209f1d9ce89be938a9a739b9195
 size 540


### PR DESCRIPTION

set the sensorScanPosition in the `bias_interpolation_brightness_temperature.nc4` to `int`

This reverts commit 379e0afdf6ae392e1b23aa198eca96203accb120.

being tested with https://github.com/JCSDA-internal/ufo/pull/2967
