### PR TITLE
Bugfix/rapid fix one file again

### DIFF
--- a/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
+++ b/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:faca424037c79e16cc2029e9b2a56049f0d28afba9a52f15d3f02af5b567df2f
-size 540
+oid sha256:42b5e623b1914c56b8be6d7e1d0e0526d1de71f75ba97381f82587a6c7c5aaa0
+size 500

--- a/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
+++ b/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59fcbdcaf8a2c6e4c9fd92954c2fb0c79fff47f2db87bdc0a7a200758dab36a7
-size 960
+oid sha256:b7850b90ccb0a30bb639cea8ecd1436e730a960b518370d9009cc4d079381d87
+size 6571

--- a/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
+++ b/testinput_tier_1/bias_interpolation_brightness_temperature.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42b5e623b1914c56b8be6d7e1d0e0526d1de71f75ba97381f82587a6c7c5aaa0
-size 500
+oid sha256:59fcbdcaf8a2c6e4c9fd92954c2fb0c79fff47f2db87bdc0a7a200758dab36a7
+size 960

--- a/testinput_tier_1/mhs_metop-b_obs_2018041500_m_interpolate_date_from_file_predictors.nc4
+++ b/testinput_tier_1/mhs_metop-b_obs_2018041500_m_interpolate_date_from_file_predictors.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b56077cf43efd2d60b6e9085ee4e68f989d4473b7a876dd11daf1d71fba7be8d
-size 51729
+oid sha256:64b27668a850d734b6afb99af3278e1670ea50ed16c39247dd9d58c57b00db15
+size 51817


### PR DESCRIPTION
## Description

Trying yet again to fix the `sensorScanPosition` in the `bias_interpolation_brightness_temperature.nc4`
also this file needs to be modified in parallel `mhs_metop-b_obs_2018041500_m_interpolate_date_from_file_predictors.nc4`

being tested with https://github.com/JCSDA-internal/ufo/pull/2970

## Issue(s) addressed

If this works, it also closes #353 and #354

## Dependencies

None

## Impact

None

