### PR TITLE
Add MetaData/surfaceQualifier

### DIFF
--- a/testinput_tier_1/scatwind_obs_1d_2020100106.nc4
+++ b/testinput_tier_1/scatwind_obs_1d_2020100106.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:293c11cb79c3c6c3ade404d181a2ab24f7643fd34a1871be7643bcf768b5d02c
-size 1909597
+oid sha256:7ac95ad595da5786efe1d72c177561e1154d8ce63607ff838818e3f286772a63
+size 1767207


### PR DESCRIPTION
## Description

This PR is simply to add a new variable, `MetaData/surfaceQualifier`, to one of the scatwind obs files. This is needed for https://github.com/JCSDA-internal/ufo/pull/2991 but has null impact on existing tests so can be merged ahead of that change.

Performing a diff on the file with nccmp shows only this difference
DIFFER : Failed to find variable surfaceQualifier in file "/downloads/scatwind_obs_1d_2020100106.nc4".
where /downloads/scatwind_obs_1d_2020100106.nc4 is the old file from develop.

## Issue(s) addressed

Resolves #361 

## Dependencies

None

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
