### PR TITLE
Modified `DateTimeOffset` test reference file

### DIFF
--- a/testinput_tier_1/function_datetimeoffset.nc4
+++ b/testinput_tier_1/function_datetimeoffset.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bbb0d747811eb7c436f1a7d8fff01d41f4cac02985b21cb4bec363f55e512cd
-size 33588
+oid sha256:893aea6d40884c3fe95e9327dd7290073bb51ac0b383ce46fdcda6f311ceb5bd
+size 86109


### PR DESCRIPTION
build-group=https://github.com/JCSDA-internal/ufo/pull/3076

## Description

Modify test reference file for `DateTimeOffset` test.

The only difference is a one-second change in one of the test reference values.


## Dependencies

None

## Impact

- [ ] JCSDA-internal/ufo#3076

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
