### PR TITLE
Adding geovals and obs files for ATMS ufo ctest

### DIFF
--- a/testinput_tier_1/atms_n20_geoval_2022021600.nc4
+++ b/testinput_tier_1/atms_n20_geoval_2022021600.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f07fcccecf90d4b92e581bda462c6bc275142a7097a2f83776b334774f377b
+size 130702

--- a/testinput_tier_1/atms_n20_obs_2022021600.nc4
+++ b/testinput_tier_1/atms_n20_obs_2022021600.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2120ffcfeda7ed82a93f2631390679140540d9076ce442cdc74dc8fa0550e264
+size 54897


### PR DESCRIPTION
## Description

The `ATMS` `ufo` ctest requires a `geovals` and `obs` file. The obs file was created by reducing a raw data file and converting to ioda format. THe geovals file was created by running the converted test data in `skylab` with the `GOMsaver` filter on. The geovals is currently too big, but will be reduced. 

Please merge at the same time as: ufo PR https://github.com/JCSDA-internal/ufo/pull/3078

## Issue(s) addressed

Resolves #3077 in ufo:  https://github.com/JCSDA-internal/ufo/issues/3077

## Dependent PR:
PR #3078 https://github.com/JCSDA-internal/ufo/pull/3078