### PR TITLE
TestReference data for RemapScanPosition variable transform ctest in ufo

### DIFF
--- a/testinput_tier_1/atms_n20_obs_20210701T1200Z_ukv.nc4
+++ b/testinput_tier_1/atms_n20_obs_20210701T1200Z_ukv.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98eab37a2e31a4781b5520a343ac9f20d45da36c19029a5ba86e911421d547a6
+size 2925319


### PR DESCRIPTION
## Description

Adds ATMS observations from Met Office local area model (UKV) where consecutive scan positions are used. Reference data `TestReference/remapScanPositionCeiling` and `TestReference/remapScanPositionFloor` are used in the revised ctest `ufo_test_tier1_test_ufo_variabletransforms_scanposition`.

## Issue(s) addressed

None

## Dependencies

To be merged with associated ufo PR:
- [ ] https://github.com/JCSDA-internal/ufo/pull/3079

## Impact

None outside ufo/ufo-data

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
