### PR TITLE
Add ocean profile data for met office duplicate check

### DIFF
--- a/testinput_tier_1/oceanprofile_duplicatecheck.nc4
+++ b/testinput_tier_1/oceanprofile_duplicatecheck.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b667e8d6c46e1674ead871efde22d3324fca622b46bea2f3e8a99f45afe7e2d5
-size 13916
+oid sha256:9440773acdeb105f867060548a2506458bce49242db62e57d9f8c781f898fb73
+size 13913

--- a/testinput_tier_1/oceanprofile_duplicatecheck.nc4
+++ b/testinput_tier_1/oceanprofile_duplicatecheck.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b667e8d6c46e1674ead871efde22d3324fca622b46bea2f3e8a99f45afe7e2d5
+size 13916


### PR DESCRIPTION
## Description

We need to add a `std::stable_sort` to the Met Office duplicate check. This ensures that the results from a single processor will match with those when multiple processors are used. None of the available test data provides different results under this test. This new data should test the feature.

## Issue(s) addressed
Part of JCSDA-internal/ufo/issues/3080

## Dependencies

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
