### PR TITLE
adding reduced obs file from ioadconverter ctest

### DIFF
--- a/testinput_tier_1/iasi_metop-b_geovals_2022021600.nc4
+++ b/testinput_tier_1/iasi_metop-b_geovals_2022021600.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b53ca0c0ace275fe45c781600273da72a832cc3e802dc590ab93d9b3099bd0d9
+size 8688072

--- a/testinput_tier_1/iasi_metop-b_obs_2021080100.nc4
+++ b/testinput_tier_1/iasi_metop-b_obs_2021080100.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffc9eccf0b6f431c899eb5058071653b39c1596962ee7daf0c4ecea2dd8d3bc3
-size 72933

--- a/testinput_tier_1/iasi_metop-b_obs_2021080100.nc4
+++ b/testinput_tier_1/iasi_metop-b_obs_2021080100.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffc9eccf0b6f431c899eb5058071653b39c1596962ee7daf0c4ecea2dd8d3bc3
+size 72933

--- a/testinput_tier_1/iasi_metop-b_obs_2022021600.nc
+++ b/testinput_tier_1/iasi_metop-b_obs_2022021600.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0629fcda86fd405707fa79b06caae81adb651328ecc590192d5b62173387f31
+size 658666


### PR DESCRIPTION
## Description

The `iasi` `ufo` ctest requires a `geovals` and `obs` file. The obs file was created by reducing a raw ioda-converted data file from the iodaconv ctest. THe geovals file was created by running the converted test data in `skylab` with the `GOMsaver` filter on. 

Please merge at the same time as: https://github.com/JCSDA-internal/ufo/pull/3091

## Issue(s) addressed

Resolves #<>  in ufo:  <>

## Dependent PR:
PR #3091 https://github.com/JCSDA-internal/ufo/pull/3091