### PR TITLE
companion of GNSSRO super refraction check 3107

### DIFF
--- a/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3df475272c6dfce3f76fb117e8e94e0e7796a767462dc7b631cd35002e1ad6ec
+oid sha256:1e71f9a39ae761623563eb37d89085bf9c53fdcbec96bc3337440b88c40896be
 size 5237173

--- a/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3df475272c6dfce3f76fb117e8e94e0e7796a767462dc7b631cd35002e1ad6ec
+size 5237173

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3cf3759ef2f9963ab556da3e4bc45c4d3d56c85212ad83fbf85faf45a5bf7ef6
-size 182570
+oid sha256:c074b5e078516c7341e136ceb18fd3f69c01cbf988f43b58fb968c9b42496eb9
+size 185366

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cf3759ef2f9963ab556da3e4bc45c4d3d56c85212ad83fbf85faf45a5bf7ef6
+size 182570

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c074b5e078516c7341e136ceb18fd3f69c01cbf988f43b58fb968c9b42496eb9
+oid sha256:8ad5033f03d5e30600a56c1799137dfce6c0510fd2ae4ca1a56fd19f9e70ec98
 size 185366


### PR DESCRIPTION
## Description

We created a new set of observations and geovals for https://github.com/JCSDA-internal/ufo/pull/3107  which implements the super refraction QC used by Meteo France.
This new test data contain refractivity observations, which is not assimialted but used by the Meteo France QC.
This new data also include diversely representative profiles in terms of latitude, setting/rising, mission, and super-refraction.  
Therefore, this data can be used for all the following gnssro QC tests.

## Issue(s) addressed

Resolves (https://github.com/JCSDA-internal/ufo/pull/3107)

## Dependencies
N/A

## Impact
N/A

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
