### PR TITLE
companion of GNSSRO super refraction check 3119

### DIFF
--- a/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3df475272c6dfce3f76fb117e8e94e0e7796a767462dc7b631cd35002e1ad6ec
+oid sha256:1e71f9a39ae761623563eb37d89085bf9c53fdcbec96bc3337440b88c40896be
 size 5237173

--- a/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3df475272c6dfce3f76fb117e8e94e0e7796a767462dc7b631cd35002e1ad6ec
+size 5237173

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3cf3759ef2f9963ab556da3e4bc45c4d3d56c85212ad83fbf85faf45a5bf7ef6
-size 182570
+oid sha256:c074b5e078516c7341e136ceb18fd3f69c01cbf988f43b58fb968c9b42496eb9
+size 185366

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cf3759ef2f9963ab556da3e4bc45c4d3d56c85212ad83fbf85faf45a5bf7ef6
+size 182570

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c074b5e078516c7341e136ceb18fd3f69c01cbf988f43b58fb968c9b42496eb9
+oid sha256:8ad5033f03d5e30600a56c1799137dfce6c0510fd2ae4ca1a56fd19f9e70ec98
 size 185366

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2736a49724ed81435cd4dec3bab74286834f31dd9e49f4a6022174fd69a4faa
+oid sha256:dfa8a32238d55e29dd324b102f022938d80a2586bf12eb17def35340e2ac00c7
 size 187631

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ad5033f03d5e30600a56c1799137dfce6c0510fd2ae4ca1a56fd19f9e70ec98
-size 185366
+oid sha256:b2736a49724ed81435cd4dec3bab74286834f31dd9e49f4a6022174fd69a4faa
+size 187631

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfa8a32238d55e29dd324b102f022938d80a2586bf12eb17def35340e2ac00c7
-size 187631
+oid sha256:ad337b91d94b127de5c0737f0d63687ee6c5104cde6f2b107b93fec4beeea06e
+size 189374


### PR DESCRIPTION
## Description

This PR adds a new variables "srCheckImpp" to the "TestReference" group for the obs file.
The generated Diag flag should match "TestReference/srCheckImpp" when running the ctest "test_ufo_gnssro_super_refraction_check".

required for https://github.com/JCSDA-internal/ufo/pull/3119

## Issue(s) addressed
N/A

## Dependencies
N/A

List the other PRs that this PR is dependent on:
N/A

## Impact
N/A

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
