### PR TITLE
Add reference values for Met Office H(x) calculation

### DIFF
--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ad5033f03d5e30600a56c1799137dfce6c0510fd2ae4ca1a56fd19f9e70ec98
-size 185366
+oid sha256:a85b19b6ecf30928ca2c99355aba10951c4b980476a2f6da5bb7fef772c31590
+size 192119

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a85b19b6ecf30928ca2c99355aba10951c4b980476a2f6da5bb7fef772c31590
-size 192119
+oid sha256:9697e0c780872fdf54fdebdfd2f8fcd9201da13572f303410a693e2f2551e522
+size 195952


### PR DESCRIPTION
Add reference values for Met Office H(x) calculation (without super-refraction check)

is required for https://github.com/JCSDA-internal/ufo/pull/3117

## Description

Provide a detailed description of what this PR does. What problem does it fix? What new capability does it add?

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact

Expected impact on downstream repositories:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
