### PR TITLE
companion of GNSSRO super refraction check 3129

### DIFF
--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ad5033f03d5e30600a56c1799137dfce6c0510fd2ae4ca1a56fd19f9e70ec98
-size 185366
+oid sha256:a85b19b6ecf30928ca2c99355aba10951c4b980476a2f6da5bb7fef772c31590
+size 192119

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48fc23d44e9c3791e0db014d2c69274a620aa11fa9e2290c49f676bfc8da914
+size 197781

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9697e0c780872fdf54fdebdfd2f8fcd9201da13572f303410a693e2f2551e522
-size 195952
+oid sha256:c48fc23d44e9c3791e0db014d2c69274a620aa11fa9e2290c49f676bfc8da914
+size 197781

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a85b19b6ecf30928ca2c99355aba10951c4b980476a2f6da5bb7fef772c31590
-size 192119
+oid sha256:9697e0c780872fdf54fdebdfd2f8fcd9201da13572f303410a693e2f2551e522
+size 195952

--- a/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_obs_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c48fc23d44e9c3791e0db014d2c69274a620aa11fa9e2290c49f676bfc8da914
+oid sha256:516f744f491c409b7d518e58ecb358ea89b3f3db4e7e305d55774554cbe2fc20
 size 197781


### PR DESCRIPTION
## Description
This PR adds a new variables "srCheckProfMaxDiff" to the "TestReference" group for the obs file.
The generated Diag flag should match "TestReference/srCheckProfMaxDiff" when running the ctest "test_ufo_gnssro_super_refraction_check".

needed for:
https://github.com/JCSDA-internal/ufo/pull/3129

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
