### PR TITLE
Update the iasi test file with two new reference datasets

### DIFF
--- a/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
+++ b/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ffe10a9fe67ea99c2162f264a671fc0c9e692d614f935eba2739f4b382de63c
-size 100292
+oid sha256:c285f53829261a1fed8f527459fbdfee5a72ca4aafbbace54dbebb3d0c336a67
+size 185214

--- a/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
+++ b/testinput_tier_1/iasi_metopb_obs_2021011500.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c285f53829261a1fed8f527459fbdfee5a72ca4aafbbace54dbebb3d0c336a67
-size 185214
+oid sha256:dd91f186205c087bca30db98f0ea675c9845701c21b60ecc2a7f929b17f68cba
+size 62085


### PR DESCRIPTION
## Description

This PR updates the `iasi_metopb_obs_2021011500.nc4` test file to include `TesReference/skinTemperature_onedvar` and `TestReference/skinTemperature_onedvar_biasTskin`.  These new arrays are used when testing the output from the files for the `ufo_test_tier1_test_ufo_iasi_rttov_ops_qc_rttovonedvarcheck` ctest in ufo. 

## Issue(s) addressed

None specifically raised.

## Dependencies

Can be merged before the ufo associated PR at:
- [ ] https://github.com/JCSDA-internal/ufo/pull/3166

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation.  Updated documentation linked as a dependency.
- [x] I have run the unit tests before creating the PR
