### PR TITLE
[Bugfix] Replace MRMS GeoVaLs file with new one using newer variable names

### DIFF
--- a/testinput_tier_1/geovals_radar_mrms_202205122200.nc
+++ b/testinput_tier_1/geovals_radar_mrms_202205122200.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54f95e75ee52af3db02483e5ed2ec16c5d32f0b386c68347bfc98967291cd60b
-size 372626
+oid sha256:ffdfb280c175a5576fdc16fd094fd952b86d83fcb51a09f2671f3d9694221801
+size 371918


### PR DESCRIPTION
## Description

The ufo radar reflectivity operator was changed to use the hydrometeor mixing ratios instead of the improper liquid or ice water path variables.  This PR updates the geovals file to have the correct variables and names.

## Issue(s) addressed

See the issue in ufo, not here.

## Dependencies

Depends on corresponding [UFO PR 3203](https://github.com/JCSDA-internal/ufo/pull/3203)

## Impact

No other repos.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
