### PR TITLE
updating cpr cloudsat obs to include layers

### DIFF
--- a/testinput_tier_1/instruments/radiance/cpr_cloudsat_geoval_2009113003.nc4
+++ b/testinput_tier_1/instruments/radiance/cpr_cloudsat_geoval_2009113003.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:561a231266cdaa52410c0a21aff04cac492dbac0fe9146725a529cc8aad2142a
-size 706530
+oid sha256:1b825a849bb98dcdc57ad2714f647b83677f658226eea5a6e735083fb0714dd6
+size 76428

--- a/testinput_tier_1/instruments/radiance/cpr_cloudsat_obs_2009113003.nc4
+++ b/testinput_tier_1/instruments/radiance/cpr_cloudsat_obs_2009113003.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9302f0580a1f32053aaf163ac042595569b21d492813975db007043e2214734
-size 36558
+oid sha256:7705db70837ee4d6a16eda0ee42b23f1d9f844ac851cbfe0be58f3bd81ac3800
+size 46412


### PR DESCRIPTION
## Description

Current cpr_cloudsat test observation don't include multiple layers so this PR updates the test observations and geovals to include multiple layers which helps the development and testing process. This needs to be merged before the ufo changes to handle layers.

build-group=https://github.com/JCSDA-internal/ufo/pull/3246

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies


## Impact

This will only impact the active observations test.

## Checklist

- [x ] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [x ] I have run the unit tests before creating the PR
