### PR TITLE
Observation test file for UFO branch feature/addoceanwindspeed 

### DIFF
--- a/testinput_tier_1/windspeed10m_obs_2020100106.nc4
+++ b/testinput_tier_1/windspeed10m_obs_2020100106.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1db5089965328f418ac315e9a227221e28b64341ab03f51eecd67bc22e051a23
+size 13138

--- a/testinput_tier_1/windspeed10m_obs_2020100106.nc4
+++ b/testinput_tier_1/windspeed10m_obs_2020100106.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1db5089965328f418ac315e9a227221e28b64341ab03f51eecd67bc22e051a23
-size 13138
+oid sha256:9a324a3ac13111f6b5e796c3ac947f7d7e75e8344dcadc8d6c26ebcbd40fe690
+size 13494


### PR DESCRIPTION
## Description
















build-group=https://github.com/JCSDA-internal/ufo/pull/3235

This PR adds the ctest observation file that goes with UFO branch  `feature/addoceanwindspeed` 

Test: `ufo_test_tier1_test_ufo_opr_windspeed10m`
Configuration: `ufo/test/testinput/unit_tests/operators/windspeed10m.yaml`

## Issue(s) addressed

Resolves #[3204](https://github.com/JCSDA-internal/ufo/issues/3204)

## Dependencies

List the other PRs that this PR is dependent on:

UFO PR #[3235](https://github.com/JCSDA-internal/ufo/pull/3235)

## Impact


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
