### PR TITLE
fix Channel value in satbis reference file

### DIFF
--- a/testinput_tier_1/satbias_amsua_n19_test1.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test1.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1f878a6656e0fcfb6f6bc668f3789764a133fa90e4f16155e4dfe63d17bbb0e
-size 8825
+oid sha256:36faef7b9c99ae05f75e8158ccb084299acfac20c4aa07a550065a0fccd50846
+size 8533

--- a/testinput_tier_1/satbias_amsua_n19_test2.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test2.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9639640ee0e8ace3c98fb72f9177b2745e56fe81c4dddc6606daf2403ac3814
-size 8484
+oid sha256:491bf1cdb939fff0eab5f1ae125c1073d6f65066a0d5502765117a9669e339f3
+size 6274

--- a/testinput_tier_1/satbias_amsua_n19_test3.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test3.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82f2bf03a176bbd41d0c33186dec6092232ba5603fb9f53f22d9cc6999d66b53
-size 8484
+oid sha256:603695b9b280ca9eb2260cae7c332707b9725809544be0f2d5b03b10f8319a19
+size 6187

--- a/testinput_tier_1/satbias_amsua_n19_test4.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test4.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39b193387182aca968967d5c4ff1166eb895d93769a41a126bc85bd363303e23
-size 8825
+oid sha256:9f03cbc17a25a0b5f944cad2181a13183377e1fc511ebc25ea00a55dc3cf6397
+size 8533

--- a/testinput_tier_1/satbias_amsua_n19_test5.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test5.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:458e66b3f9ef131e645c10d3cab7c31f1e55fc0cd9c8e15a57b7ea5f36aa089d
-size 8484
+oid sha256:6ff7773295f7f37c78e5afd73d0b1a4d415c33d3c7c2bf03c743505e8dedf0be
+size 6187

--- a/testinput_tier_1/satbias_amsua_n19_test6.nc4
+++ b/testinput_tier_1/satbias_amsua_n19_test6.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ec76aaa39b46f4a0d34f22dfdd46096b4bbff87ddfab4203c652474f066202c
-size 14424
+oid sha256:c7eb52a7d3a06ec4760439df489c6b77a9aeda219e22b03be71e6ebd5ecaf319
+size 14132


### PR DESCRIPTION
## Description

This PR fixes the reference files used for a few satbias coefficient tests. The fixes were discussed in the [UFO issue #3329](https://github.com/JCSDA-internal/ufo/issues/3329) and also the [UFO PR#3330](https://github.com/JCSDA-internal/ufo/pull/3330). 

One of the reference files before and after the fix is shown below:

<img width="1631" alt="image" src="https://github.com/JCSDA-internal/ufo-data/assets/37095643/549b6f7f-9c19-422b-b13f-9450214c4a1c">





## Issue(s) addressed

Resolves [UFO issue #3329](https://github.com/JCSDA-internal/ufo/issues/3329) 

## Dependencies

None

## Impact

Since the associated satbis ctest doesn't check the value of Channel in the reference file, there is no impact on the existing ctest result. 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
