### PR TITLE
Add missing data for ufo changes to Arithmetic and RadToBT variable transform

### DIFF
--- a/testinput_tier_1/RadToBT_obs_2021071200.nc4
+++ b/testinput_tier_1/RadToBT_obs_2021071200.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f2b4a590b6977f9274456bc0aeec1bf3dce03acacf55fddc4c6db4f40dc8678
-size 46193
+oid sha256:5ba0233ff80608eddd2a31ceff7111ca62e546f763fafcf9760345c2b63411c6
+size 46040


### PR DESCRIPTION
## Description

This PR adds some missing data to the rad to bt test data.  This does two things.

1. Tests the changes made with the associated ufo PR relating to the `Arithmetic` obs function.
2. Tests the updated code in the variable transform.

## Issue(s) addressed

https://github.com/JCSDA-internal/ufo/issues/3382

## Dependencies

To be merge with the associated ufo pr:
- [x] https://github.com/JCSDA-internal/ufo/pull/3401

## Impact

None outside of ufo and ufo-data

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
