### PR TITLE
Update filter_testdata to add more reference variables

### DIFF
--- a/testinput_tier_1/filters_testdata.nc4
+++ b/testinput_tier_1/filters_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72b9c813827bb19eed15489c118a1e7c50aa89ca80ae12ab1771428ad79ffb57
-size 111653
+oid sha256:2169d426ec5c6445dbce35689c664715de6b7c1063d3a07f365e8a9f06e59234
+size 286890


### PR DESCRIPTION
## Description

Updates `filter_testdata` to add more reference variables for testing diagnostic flags bitmap. The new variables:

```
group: TestReference {
  variables:
  	int zeroes(Location) ;
  		zeroes:_FillValue = -2147483643 ;
  	int ones(Location) ;
  		ones:_FillValue = -2147483643 ;
  	int twos(Location) ;
  		twos:_FillValue = -2147483643 ;
  	int threes(Location) ;
  		threes:_FillValue = -2147483643 ;
  data:

   zeroes = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;

   ones = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;

   twos = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;

   threes = 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 ;

  } // group TestReference
```

## Impact

Required for [ufo PR3420](https://github.com/JCSDA-internal/ufo/pull/3420), can be merged before that.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
