### PR TITLE
Add filter testdata for variables with channels

### DIFF
--- a/testinput_tier_1/filters_testdata_channels.nc4
+++ b/testinput_tier_1/filters_testdata_channels.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be3bbbbabd5237bf8eb405259b99c377eed25708b82e97530fb8edafae1ee4ad
+size 15276


### PR DESCRIPTION
## Description

Adds a simple test file for testing filter flags capabilities with variables with channels. File dump for relevant variables:

```
netcdf filters_testdata_channels {
dimensions:
	Channel = 2 ;
	Location = 10 ;
...

data:
 Channel = 3, 5 ;

...

group: HofX {
  variables:
  	float variable1(Location, Channel) ;
  	float variable2(Location, Channel) ;
  ...
  } // group HofX

group: MetaData {
  variables:
  	int64 dateTime(Location) ;
  	float latitude(Location) ;
  	float longitude(Location) ;

  data:

   latitude = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ;

  } // group MetaData

group: ObsError {
  variables:
  	float variable1(Location, Channel) ;
  	float variable2(Location, Channel) ;
 } // group ObsError

group: ObsValue {
  variables:
  	float variable1(Location, Channel) ;
  	float variable2(Location, Channel) ; 
  } // group ObsValue

group: TestReference {
  variables:
  	byte falses(Location, Channel) ;
  	byte trues(Location, Channel) ;
  	byte falses_trues(Location, Channel) ;
  	int zeroes(Location, Channel) ;
  	int zeroes_ones(Location, Channel) ;
  	int ones(Location, Channel) ;
 
 data:

   falses =
  0, 0,
 ...
   trues =
  1, 1,
 ...
   falses_trues =
  0, 1,
  ...
   zeroes =
  0, 0,
  ...
   zeroes_ones =
  0, 1,
  ...
   ones =
  1, 1,
  ...
  } // group TestReference
}
```

Supporting https://github.com/JCSDA-internal/ufo/pull/3438