### PR TITLE
Update files to support aircraft BC tests

### DIFF
--- a/testinput_tier_1/aircraftBCOffline_obs.nc4
+++ b/testinput_tier_1/aircraftBCOffline_obs.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7012d281ec47bf46263a3bb52c88bc1e6f2efb60cc23d5962658141f7f21fd9f
-size 360783
+oid sha256:e7747e24bab5c19c9bf799f0f44b7fbf0daf76f7be2fc449e518c56f7867db38
+size 361088

--- a/testinput_tier_1/aircraft_artificial_bias.nc4
+++ b/testinput_tier_1/aircraft_artificial_bias.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0dede80dbdc94e32719f3565c6df0c33e2eebd4ac17d3745c010b8de6df21c13
-size 10124
+oid sha256:a00f8ecad1b01a1798f997dde0ce685210a62784baebfba076a4f21495e9be0a
+size 10483

--- a/testinput_tier_1/aircraft_artificial_bias_2.nc4
+++ b/testinput_tier_1/aircraft_artificial_bias_2.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42f21b65924d11dabc520c6d2ac30195bc3e516b93311a8e1f0072ea63c91233
-size 10128
+oid sha256:56038cd65a6fd33781e8027d7bacb2614f0c57a9a874dd5fe5196f9dee864266
+size 8324

--- a/testinput_tier_1/aircraft_bias_20210731T18Z.nc4
+++ b/testinput_tier_1/aircraft_bias_20210731T18Z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a903715de3d936ec0d48bc3c05ccb298007a3169504335efb564aaca32333e
+size 394706

--- a/testinput_tier_1/aircraft_obs_20190801T0000Z_aircraft_predictors.nc4
+++ b/testinput_tier_1/aircraft_obs_20190801T0000Z_aircraft_predictors.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbb27cbf634ca34bfb7f692a47feb3c55ba204d0ebfcf16552acb0c5674c2fbb
-size 379748
+oid sha256:6f877a1471a9430c65a40a1eae40db1bc37ca47de247b8f3935f0d2989eeb74f
+size 380159


### PR DESCRIPTION
## Description

Update for supporting aircraft BC tests:
- new: aircraft_bias_20210731T18Z.nc4: aircraft bias correction file generated by @nicholasesposito using ioda-converters
- aircraftBCOffline_obs.nc4: aircraftVerticalVelocity renamed to aircraftAscentRate
- aircraft_artificial_bias.nc4 and aircraft_artificial_bias_2.nc4: fixed dimension variable (Variable) and added string variable (Variables) to be consistent with converters and ufo code
- aircraft_obs_20190801T0000Z_aircraft_predictors.nc4: renamed predictor variable names to be consistent with ufo code.

## Impact

Supporting https://github.com/JCSDA-internal/ufo/pull/3456

## dependencies

- [x] https://github.com/JCSDA-internal/ioda/pull/1340

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
