### PR TITLE
Switch aircraft record to first dimension

### DIFF
--- a/testinput_tier_1/aircraft_bias_20210731T18Z.nc4
+++ b/testinput_tier_1/aircraft_bias_20210731T18Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5a903715de3d936ec0d48bc3c05ccb298007a3169504335efb564aaca32333e
-size 394706
+oid sha256:77b858bf8eb87959e54284325442c7737a73f8d7aa8e4fedccd5014eadd4a03e
+size 631406


### PR DESCRIPTION
## Description

This PR switches the aircraft bias file so the dimensions are [Record, Variable] rather than [Variable, Record].  This is the style agreed at this discussion () and it fixes some tests failures with debug builds which don't collapse the array dimensions.

## Issue(s) addressed

Resolves issues in ufo (e.g. https://github.com/JCSDA-internal/ufo/issues/3480)

## Dependencies

To be merged with the associated ufo PR:
- [ ] https://github.com/JCSDA-internal/ufo/pull/3500

## Impact

Ctests passing in debug builds.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation ( not needed)
- [x] I have run the unit tests before creating the PR
