### PR TITLE
Added MetaData/dumpReportType (prepbufr T29) for ufo PR 3512

### DIFF
--- a/testinput_tier_1/instruments/conventional/aircraft_obs_2021121200_m.nc4
+++ b/testinput_tier_1/instruments/conventional/aircraft_obs_2021121200_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc3c1a2902f9825ba062fa77be20415841626c2d06d8120fc17ac4c937cbdb6d
-size 511860
+oid sha256:270134397fb6d2d1f515629dd846959bc61ec0114cefef49777f13bbd3281ab5
+size 520500

--- a/testinput_tier_1/instruments/conventional/pibal_obs_2021121200_m.nc4
+++ b/testinput_tier_1/instruments/conventional/pibal_obs_2021121200_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75b8d199de05342266679f1ad10d9d6f624910afd6f0861c427869eebb484f96
-size 167697
+oid sha256:93963c27d74aa7e23711542ccd2d50d137f083ceed69b25a19d4a2d2d7a1f574
+size 176337

--- a/testinput_tier_1/instruments/conventional/satwind_obs_2021121200_m.nc4
+++ b/testinput_tier_1/instruments/conventional/satwind_obs_2021121200_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d474027fac2987846f774accdb5b278bd306210ab55da4ee20e8cd44b8142675
-size 469558
+oid sha256:d7cf31fed89e2738d55646dbdc8b0aef61608baf3bbf5f20c5c4a1acab4dae82
+size 478198

--- a/testinput_tier_1/instruments/conventional/sfcship_obs_2021121200_m.nc4
+++ b/testinput_tier_1/instruments/conventional/sfcship_obs_2021121200_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e5b12086f3ed6b8b8eca52f7ee22f22db7121f041e2f0570abe79c612fc0404
-size 640122
+oid sha256:c9fbc6901f74bb1bae488d05b86d22105c8a1a196f16c6cd014afce337574024
+size 650621

--- a/testinput_tier_1/instruments/conventional/sondes_obs_2021121200_m.nc4
+++ b/testinput_tier_1/instruments/conventional/sondes_obs_2021121200_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5712fa5306d7a5fffc287c33b68f9677550d8d12fadd1e3738b6da323939f34
-size 644737
+oid sha256:6967fc8226eeae7b4a232bf431ae50f1a306c18423fc0618e9b1a5146989e0c5
+size 655236


### PR DESCRIPTION


## Description

This PR fixes unit test failures noted in https://github.com/JCSDA-internal/ufo/pull/3512. MetaData/dumpReportType was added to the following netcdf files:

- aircraft_obs_2021121200_m.nc4
- pibal_obs_2021121200_m.nc4
- satwind_obs_2021121200_m.nc4
- sfcship_obs_2021121200_m.nc4
- sondes_obs_2021121200_m.nc4

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:
- https://github.com/JCSDA-internal/ufo/pull/3512

## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
