### PR TITLE
Add test data for obsfunction to calculate tropopause height level from model fields.

### DIFF
--- a/testinput_tier_1/tropopauseheight_testdata.nc4
+++ b/testinput_tier_1/tropopauseheight_testdata.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b2f603780d0bd601c5efb38fd942ccbea6c05970d8baef16e8728f23a32d655
+size 11914

--- a/testinput_tier_1/tropopauseheight_testdata.nc4
+++ b/testinput_tier_1/tropopauseheight_testdata.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b2f603780d0bd601c5efb38fd942ccbea6c05970d8baef16e8728f23a32d655
-size 11914
+oid sha256:f944553f4930457ead94356d482da6e59d99d4ed4a6a9f5efc4681f077b98c08
+size 12321

--- a/testinput_tier_1/tropopauseheight_testdata_geovals.nc4
+++ b/testinput_tier_1/tropopauseheight_testdata_geovals.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:048b8ef1ff5f15cbe6bacd39da18ffb8ca93881dc440ffeafac3881716cf2fcf
+size 15511


### PR DESCRIPTION
## Description

This PR adds test data for ufo PR #3520.

build-group=https://github.com/JCSDA-internal/ufo/pull/3520

## Dependencies

List the other PRs that this PR is dependent on:
- [x] ufo https://github.com/JCSDA-internal/ufo/pull/3520

## Impact

Expected impact on downstream repositories: None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
