### PR TITLE
Add test files which contain one observation

### DIFF
--- a/testinput_tier_1/2020100106_metars_small_oneob.nc4
+++ b/testinput_tier_1/2020100106_metars_small_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44f2f46333d9369b4278ab75a942677f2ed5ee076114559a2a07e794d2b09a8f
+size 97294

--- a/testinput_tier_1/met_office_conversion_td2Rh_surface_oneob.nc4
+++ b/testinput_tier_1/met_office_conversion_td2Rh_surface_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5fc7f6fd8578d38975319d4522db13310d2f6898b35a903c067ff9069a600a2
+size 23040

--- a/testinput_tier_1/mixRatio2RH_conversion_aircraft_oneob.nc4
+++ b/testinput_tier_1/mixRatio2RH_conversion_aircraft_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b171978e4b46e283d64ec8c29f2bbac9c9c104dede6f438ac79ee359bb856503
+size 260601

--- a/testinput_tier_1/sfc_obs_2018041500_metars_oneob.nc4
+++ b/testinput_tier_1/sfc_obs_2018041500_metars_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7d3bc2acac5c59f6292d300b83a30e521388bf359a6f7ed49f000093ede8c8c
+size 90245

--- a/testinput_tier_1/sfc_obs_2018041500_metars_small2_oneob.nc4
+++ b/testinput_tier_1/sfc_obs_2018041500_metars_small2_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca6490f2e11cccde6826f29de1ae5537c005688797c4a0ba1d5e1dd9c4c57679
+size 19755


### PR DESCRIPTION
## Description

This pr adds single observation test files for relative humidity, specific humidity and potential temperature variable transforms.  These are needed to allow the testing of the transforms when there are zero observations of a mpi thread.  This has found to be problematic for operational runs and the associated PR fixes this for these variable transforms.

## Issue(s) addressed

None raised in this repository.  But links to the UFO issue here:
https://github.com/JCSDA-internal/ufo/issues/3521

## Dependencies

To be merged with the associated UFO PR:
- [ ] ...

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation, none needed.
- [x] I have run the unit tests before creating the PR
