### PR TITLE
RTTOVOneDVarCheck fix zero obs on a MPI task

### DIFF
--- a/testinput_tier_1/geovals_iasi_2021011500Z_oneob.nc4
+++ b/testinput_tier_1/geovals_iasi_2021011500Z_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8281c0574caa5bee1b8fe1bc9584f568ca55fdcb916cf7ae54c7862708d5745f
+size 17363

--- a/testinput_tier_1/iasi_metopb_obs_2021011500_oneob.nc4
+++ b/testinput_tier_1/iasi_metopb_obs_2021011500_oneob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddd05b472a457704d12d17c13670ec4c78b3765e24c03bcad212d636439d1bda
+size 29880


### PR DESCRIPTION
## Description

This PR adds two new files with a single observation to test the functionality which allows the RTTOVOneDVarCheck to complete successfully when one of the MPI tasks has zero observations on a MPI task.

It is worth adding this additional testing to ensure that any writing added to the filter is tested for a zero obs case.

## Issue(s) addressed

Resolves an issue in ufo.

## Dependencies

To be merged with the companion PR in ufo:  https://github.com/JCSDA-internal/ufo/pull/3531


## Impact

More stable performance of the filter in ufo.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (no update needed)
- [x] I have run the unit tests before creating the PR
