### PR TITLE
Expand superob test data set to include the `mean obs` algorithm

### DIFF
--- a/testinput_tier_1/superob.nc4
+++ b/testinput_tier_1/superob.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61b022b357e18aa41afc6236367fb83bb3aa4aa12979ed84626e2a7325fccd3c
-size 13708
+oid sha256:383c569961a3c8bcde8596ec6cacea5d89d0543680d68f0142c04ec111162b8d
+size 14583


### PR DESCRIPTION
## Description

Expand superob test data set to include the `mean obs` algorithm.

## Dependencies

N/A

## Impact

build-group=https://github.com/JCSDA-internal/ufo/pull/3541