### PR TITLE
Add three files with one observation to changes updates to variable change methods

### DIFF
--- a/testinput_tier_1/RadToBT_obs_2021071200_1ob.nc4
+++ b/testinput_tier_1/RadToBT_obs_2021071200_1ob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ed4c60d532d6b7d95710e204eeb8a56b9138280c444fb2ed2d345e6878327c5
+size 35004

--- a/testinput_tier_1/met_office_conversion_height2pressure_1ob.nc4
+++ b/testinput_tier_1/met_office_conversion_height2pressure_1ob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37880d8334cdd1cac7cd38bab6eea43f984fb8b0ad5fb893404ae2b467851056
+size 32889

--- a/testinput_tier_1/met_office_conversion_pressure2height_1ob.nc4
+++ b/testinput_tier_1/met_office_conversion_pressure2height_1ob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:125cc3621ed95a8dc233c670683743570043ca56198c68e8e7dae5f752d4d6ff
+size 36855


### PR DESCRIPTION
## Description

This PR adds three data files which contain just a single `Location`.  This goes with the ufo PR which has changed these tests to be run on 2 mpi threads to make sure that in the case of zero observations on a PE the arrays are written back to the ObsSpace and don't cause crashes.

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ufo/issues/3446

## Dependencies

To be merged with the assoicated ufo pr here:
- [x] https://github.com/JCSDA-internal/ufo/pull/3584

## Impact

Expected impact on downstream repositories:

There has been a change so that the variable transforms are by default run on processors with zero PE's.  This should be a positive impact because it ensures no failures when the ObsSpace is bought back together but worth noting for downstream users.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
