### PR TITLE
Add single ob version for testing fewer obs than MPI ranks

### DIFF
--- a/testinput_tier_1/satwind_obs_1d_2020100106_noinv_qiODB_1ob.nc4
+++ b/testinput_tier_1/satwind_obs_1d_2020100106_noinv_qiODB_1ob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c829353effdbdc14029841f9633b050e26712e1248abefb3a4946b226537697
+size 101850


### PR DESCRIPTION
## Description

This PR adds a data files which contains just a single Location. This is needed for the associated ufo PR which tests the case where it is run on 2 MPI to ensure it does not fail when there is zero obs on a PE. 

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

Required for https://github.com/JCSDA-internal/ufo/pull/3596

## Impact

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
