### PR TITLE
Update slmsk variable to geoval and reference for constant predictor ctest

### DIFF
--- a/testinput_tier_1/atms_obs_20191230T0000_rttov_predictors.nc4
+++ b/testinput_tier_1/atms_obs_20191230T0000_rttov_predictors.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57f914f821a2aadb6667ff960efb25d1d03fabd6982107c878c09f4cefeba45e
-size 115088
+oid sha256:f76190ee0f184c17d694c8b49e45b8519c09fbd7a54f53af70915f392bdb1e06
+size 136328

--- a/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark.nc4
+++ b/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f73d7abcacb212d88e4832c35d4f3a48c53932d595c23e604f5b97601aef374
-size 280217
+oid sha256:fd9886710e993d2c81bad9607fa5a817fe26ac6deed69ee022608781eb81c635
+size 277143

--- a/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark.nc4
+++ b/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd9886710e993d2c81bad9607fa5a817fe26ac6deed69ee022608781eb81c635
-size 277143
+oid sha256:ac9e0ea68e96311fad3e9e0f9f607d57dcbb2613cd6f1238c14e80282ebc49f1
+size 277510

--- a/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark.nc4
+++ b/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac9e0ea68e96311fad3e9e0f9f607d57dcbb2613cd6f1238c14e80282ebc49f1
-size 277510
+oid sha256:829aaa1092bba5d96b2642c3c9b57b0b38d13d13a2d02fae1bf0c4d68a271376
+size 277516


### PR DESCRIPTION
## Description

This PR adds sea-land mask variable to geoval file and update reference in the obs files for the updated ufo tests `ufo_test_tier1_test_ufo_constant_predictor` in ufo PR https://github.com/JCSDA-internal/ufo/pull/3627

## Issue(s) addressed

Issue in ufo: https://github.com/JCSDA-internal/ufo/issues/3625

## Dependencies

List the other PRs that this PR is dependent on:
None.

## Impact

Expected impact on downstream repositories: ufo

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
