### PR TITLE
add satelliteAscendingFlag to MetaData

### DIFF
--- a/testinput_tier_1/instruments/radiance/ssmis_f17_obs_2020110112_m.nc4
+++ b/testinput_tier_1/instruments/radiance/ssmis_f17_obs_2020110112_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b61f3b42590d3c2d79db57f7e1348621c2366a38dc45fed1285d043b75550a8e
-size 104334
+oid sha256:388703a48d83b2b9219af26fbdcf7c2ce08f1432c745a3637504f4b39e608c9c
+size 104921

--- a/testinput_tier_1/instruments/radiance/ssmis_f17_obs_2020110112_m.nc4
+++ b/testinput_tier_1/instruments/radiance/ssmis_f17_obs_2020110112_m.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:388703a48d83b2b9219af26fbdcf7c2ce08f1432c745a3637504f4b39e608c9c
+oid sha256:467e8605aac51c2c75f64d8a528e5607d4678e301ea0765dc9c51397c03e5ea9
 size 104921


### PR DESCRIPTION
## Description

the bias correction for SSMIS and corresponding ctest correctly looks for the ascending and descending node.  This was incorrectly using the `sensorAzimuthAngle` 

the values in this `MetaData` were either `1` for ascending or `-1` for descending.  A new field was created `satelliteAscendingFlag` and the values remained `1` for ascending and the descending is now indicated by `0`

companion to [UFO PR3684](https://github.com/JCSDA-internal/ufo/pull/3684)

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ufo/issues/3681

## Impact

The SSMIS unit tests for predictors no longer fail looking for the `satelliteAscendingFlag`

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the unit tests before creating the PR
