### PR TITLE
Fix problems with missing data in ObsValues in GNSS-RO data file

### DIFF
--- a/testinput_tier_1/gnssro_obs_2019123006_refractivity_nopseudo.nc4
+++ b/testinput_tier_1/gnssro_obs_2019123006_refractivity_nopseudo.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c49dfdde59dbd0ffd023fc6ea13ce1042cecff50b9b8d6b93533bfce27e1b460
-size 61273
+oid sha256:227d6c06d0dd9db1fc3aa417e1101d1b1f9b6cf82f5b3d73cca6d21f404b2923
+size 65126


### PR DESCRIPTION
## Description

This is a companion PR to https://github.com/JCSDA-internal/ufo/pull/3707.  This makes a small update to one of the GNSS-RO observation files.  In the old version of the file, missing data were represented by -1e10.  Now the netCDF flag value is used, so that the data are correctly read in as missing.

## Issue(s) addressed

-

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] https://github.com/JCSDA-internal/ufo/pull/3707

## Impact

Expected impact on downstream repositories:
None

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
