### PR TITLE
Update jedi-ci for ufo data.

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -1,0 +1,49 @@
+name: start-jedi-ci
+
+on:
+  pull_request:
+    branches:
+     - 'master'
+     - 'main'
+     - 'develop'
+
+jobs:
+  launch-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+
+      - name: Generate CI App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          # Owner is specified to scope the token to the org install
+          # otherwise the token will be scoped to the repository.
+          app-id: 321361
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: target_repository
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # This role only has the permission to write to our lfs archive s3 bucket path.
+          role-to-assume: arn:aws:iam::747101682576:role/service-role/jedi-ci-action-runner-backend-GitHubActionsIAMRole-HkHdJRVEFw3x
+          aws-region: us-east-2
+
+      - name: Run JEDI CI
+        uses: JCSDA-internal/jedi-ci@feature/test-deps
+        with:
+          container_version: 'latest'
+          unittest_tag: 'ufo'
+          test_script: run_tests.sh
+          target_repo_dir: target_repository
+          bundle_branch: develop
+          jedi_ci_token: ${{ steps.generate-token.outputs.token }}
+          unittest_dependencies: crtm ioda oops gsw ufo-data oasim ropp-ufo rttov

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -38,7 +38,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Run JEDI CI
-        uses: JCSDA-internal/jedi-ci@feature/test-deps
+        uses: JCSDA-internal/jedi-ci@feature/oops-fixes
         with:
           container_version: 'latest'
           unittest_tag: 'ufo'


### PR DESCRIPTION
UFO data was on the old AWS-codebuild based continuous integration pipeline that was outdated. This PR updates UFO data.

Note this PR references the branch `@feature/oops-fixes` which contains the last batch of updates for the CI overhaul. I will update this to `develop` once https://github.com/JCSDA-internal/jedi-ci/pull/15 is merged but in the meantime the current branch represents the final ready state of the system that will be rolled out over the next few weeks.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
