### PR TITLE
Add ioda-data to unittest_dependencies for CI

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -46,4 +46,4 @@ jobs:
           target_repo_dir: target_repository
           bundle_branch: develop
           jedi_ci_token: ${{ steps.generate-token.outputs.token }}
-          unittest_dependencies: crtm ioda oops gsw ufo-data oasim ropp-ufo rttov
+          unittest_dependencies: crtm ioda ioda-data oops gsw ufo-data oasim ropp-ufo rttov


### PR DESCRIPTION
## Description

Since the https://github.com/JCSDA-internal/ufo-data/pull/507 CI need data files to be added as dependency to make sure the files are available for ctest.

jedi-ci-test-select=gcc

## Issue(s) addressed


## Dependencies


## Impact

Fix CI test to pass.

## Manual Testing Instructions (optional)


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
