### PR TITLE
Remove data files associated with atmsfcinterp operator

### DIFF
--- a/testinput_tier_1/instruments/conventional/scatwind_geoval_2020121500_m.nc
+++ b/testinput_tier_1/instruments/conventional/scatwind_geoval_2020121500_m.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c01e349c39f0165ca875318a210f14e151524cff43629b57e5e7c346cbcdb3fe
-size 11075482

--- a/testinput_tier_1/instruments/conventional/sfc_geoval_2020121500_m.nc
+++ b/testinput_tier_1/instruments/conventional/sfc_geoval_2020121500_m.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5366d75155a8cd9e81639374cef51e1a2549af7eff886275f4e337bacc4d89f3
-size 11484720

--- a/testinput_tier_1/instruments/conventional/sfcship_geoval_2020121500_m.nc
+++ b/testinput_tier_1/instruments/conventional/sfcship_geoval_2020121500_m.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98af86f1cf3cde57495f44809cddeccac73dc6a4b2055a80444f567b3aa03e11
-size 10641174

--- a/testinput_tier_1/instruments/conventional/sfcship_obs_2020121500_m.nc
+++ b/testinput_tier_1/instruments/conventional/sfcship_obs_2020121500_m.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f40c33d0d90347bba5cbcb673e960094f428934950da4aa4ec33e66d1483729
-size 651872

--- a/update_part2.py
+++ b/update_part2.py
@@ -89,8 +89,8 @@ if __name__ == '__main__':
 #    renameVariableInDataFile(workingDir, "water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_background_error", "water_vapor_mixing_ratio_wrt_moist_air_background_error")
 
 #    # List of variables to remove condensed water from
-#    files = ["gnssro_geoval_2018041500_1obs_bending_angle.nc4", "scatwind_geoval_2020121500_m.nc", "sfc_geoval_2020121500_m.nc", 
-#             "sfcship_geoval_2020121500_m.nc", "gnssro_geoval_2018041500_3prof.nc4", "rass_tv_geoval_2020121500.nc",
+#    files = ["gnssro_geoval_2018041500_1obs_bending_angle.nc4",
+#             "gnssro_geoval_2018041500_3prof.nc4", "rass_tv_geoval_2020121500.nc",
 #             "sondes_geovals_2021121200_m.nc4", "scatwind_geovals_2021121200_m.nc4",
 #             "vadwind_geoval_2020121500.nc", "sfcship_geovals_2021121200_m.nc4", "pibal_geovals_2021121200_m.nc4",
 #             "pibal_geoval_2021121200_m.nc4", "satwind_geovals_2021121200_m.nc4", "aircraft_geovals_2021121200_m.nc4",


### PR DESCRIPTION
## Description

https://github.com/JCSDA-internal/ufo/pull/3852 removes the atmsfcinterp operator and the ctest. This PR removes the associated data files, since they are not used by any other tests.

## Issue(s) addressed

Resolves #https://github.com/JCSDA-internal/ufo/issues/3284

## Dependencies

List the other PRs that this PR is dependent on:
(https://github.com/JCSDA-internal/ufo/pull/3852)

## Impact
None

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [X] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [] I have run the unit tests before creating the PR
