### PR TITLE
Fix the test file to match the variables changed

### DIFF
--- a/testinput_tier_1/radar_rw_obs_2020101300_m.nc
+++ b/testinput_tier_1/radar_rw_obs_2020101300_m.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4973ffa0fb416b987a3f7135d6c95d8ce81cb0eca418580678682ac1339dcaf
+size 90752

--- a/testinput_tier_1/radar_rw_obs_2020101300_m.nc4
+++ b/testinput_tier_1/radar_rw_obs_2020101300_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ecbbc5345a571e84419469c4d28f4d0dffbc9d65bfa1496756e7b470d368fbf
-size 85425


### PR DESCRIPTION
## Description

Fix the variable names in the obs file to match ufo PR#3845, that changed cosazm_costilt, sinazm_costilt, sintilt to cosAzimuthCosTilt, sinAzimuthCosTilt, sinTilt respectively.

## Issue(s) addressed

Resolves #https://github.com/JCSDA-internal/ufo/issues/3846

## Dependencies

List the other PRs that this PR is dependent on:
- https://github.com/JCSDA-internal/ufo/pull/3845

## Impact

## Manual Testing Instructions (optional)

ctest -R ufo_test_tier1_test_ufo_opr_radialvelocity

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
