### PR TITLE
Add two small atms files to allow for testing of zero obs on a rank for the rttov operator

### DIFF
--- a/testinput_tier_1/atms_n20_obs_20191230T0000_rttov_1ob.nc4
+++ b/testinput_tier_1/atms_n20_obs_20191230T0000_rttov_1ob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f43f0b3ab64f15b3fb90ea2d429ce69ed99de8f81805c84024c1433c195604f
+size 27842

--- a/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark_1ob.nc4
+++ b/testinput_tier_1/geovals_atms_20191230T0000Z_benchmark_1ob.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9bfa4a902be9bd8a9ad2afa817b0f9cb7414e67208814084bdd6a1ca9fe349d
+size 22620


### PR DESCRIPTION
## Description

These data files are needed for the additional test added here:
https://github.com/JCSDA-internal/ufo/pull/3868

## Issue(s) addressed

None

## Dependencies

To be merged with ufo pr:
- https://github.com/JCSDA-internal/ufo/pull/3868

## Impact

None

## Manual Testing Instructions (optional)

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation.  None needed.
- [x] I have run the unit tests before creating the PR
