### PR TITLE
Adding instrument metadata to abi file

### DIFF
--- a/testinput_tier_1/abi_g16_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/abi_g16_obs_2018041500_m_qc.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:622cd47aa096392205c160d9c302616ce3d0c637e59c6e432cbb2bb5d332613e
-size 76378
+oid sha256:9a4d1b75eb0665e0498abd45182805a36d2447bf1d2bfd86d7c84473505b9ad5
+size 76417


### PR DESCRIPTION
## Description

This adds metadata fields:
```
  	int instrumentIdentifier(Location) ;
  		instrumentIdentifier:_FillValue = -2147483648 ;
  	int satelliteIdentifier(Location) ;
  		satelliteIdentifier:_FillValue = -2147483648 ;
```
With values of `270` and `617` respectively so that the obs can be grouped and used by the WithinGroupCovariance Obs Error operator.

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ufo-data/issues/521

No impact expected

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
