### PR TITLE
Remove unused reversed geoval files

### DIFF
--- a/testinput_tier_1/geovals_atms_20191230T0000Z_predictors_reversed.nc4
+++ b/testinput_tier_1/geovals_atms_20191230T0000Z_predictors_reversed.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f986fdb000011814719d74a549ab7fcf55fda7b1d99001d389a714dc5c54587e
-size 28968

--- a/testinput_tier_1/met_office_conventional_profile_processing_average_geovals_extended_reversed.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_average_geovals_extended_reversed.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01afda7519f093ca0a28eddf030d3d97987419149147ed9bd4d92a2163e48fb5
-size 14708600

--- a/testinput_tier_1/met_office_conventional_profile_processing_profileaverageobs_geovals_reversed.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_profileaverageobs_geovals_reversed.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25c9c22f5c27d1f644f05067dfe8fa7388c05f350ebd2eebae2180def38765a7
-size 98940

--- a/testinput_tier_1/met_office_conventional_profile_processing_unittests_vertinterp_geovals_reversed.nc4
+++ b/testinput_tier_1/met_office_conventional_profile_processing_unittests_vertinterp_geovals_reversed.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4448f3969c9ecb20857b9b324654e837aa2be4d2377cacceb5fe65d77f1ec968
-size 38822

--- a/testinput_tier_1/met_office_profile_cxinterpolation_geovals_reversed.nc4
+++ b/testinput_tier_1/met_office_profile_cxinterpolation_geovals_reversed.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2378244be1ee212320170c73b25aa702f6c8537193e87d4f5f673302b35df97f
-size 5104094

--- a/testinput_tier_1/satwind_geoval_small_reversed_20201001T0600Z.nc4
+++ b/testinput_tier_1/satwind_geoval_small_reversed_20201001T0600Z.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84024c346d89800eb05ab8761f4a0e0e670ebfcb82828762fd54f10b64eef9d6
-size 44670


### PR DESCRIPTION
## Description

https://github.com/JCSDA-internal/ufo/pull/3889 removes some validations and tests that are no longer necessary. This PR removes some test files that were only used to support tests that are removed in that PR.

Related to [issue #3327](https://github.com/JCSDA-internal/ufo/issues/3327)

build-group=https://github.com/JCSDA-internal/ufo/pull/3889

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] https://github.com/JCSDA-internal/ufo/pull/3889

