### PR TITLE
Move ufo-data validate obs file logic to ufo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,48 +15,5 @@ include( ecbuild_system NO_POLICY_SCOPE )
 ecbuild_declare_project()
 set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
 
-# This CMake script adds many tests to validate all of the testing data files
-# within the ufo-data repository.
-
-find_package(ioda REQUIRED)
-
-file( GLOB_RECURSE OBS_FILES *.nc4 *.nc *.ioda )
-# We filter the expression to remove the geovals and obsdiag files, which are geovals-based
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)geoval(.*)" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)obsdiag(.*)" )
-# Remove satbias files
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)satbias(.*)" )
-# Remove misc test files
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)interpolation(.*)" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)obserror_multi_variant(.*)" )
-
-# Remove known buggy non-obs files
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)met_office_gauss_thinning_groundgnssnames_obs.nc4" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)obserror_4d.nc" )  # Wrong dimension attachment
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)obserror_2d_fullr.nc" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)obserror_latitude_longitude.nc" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)satwind_pressure_errors.nc4" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)satwind_pressure_errors_nomissing.nc4" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)scatwind_obs_2d_2020100106.nc4" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)superob_testdata.nc4" )
-list( FILTER OBS_FILES EXCLUDE REGEX "(.*)mtgirs_obserror_fstest.nc4" )  # used with drawFromFile obsfunction
-
-foreach ( f ${OBS_FILES} )
-	get_filename_component(filename ${f} NAME)
-
-	# Note: IODA_YAML_ROOT is provided by find_package(ioda).
-	# The ObsSpace.yaml file is *not* a test file. It always exists.
-	ecbuild_add_test(
-		TARGET ufo_data_validate_${filename}
-		COMMAND ioda-validate.x
-		LABELS ufo_data_validate
-		ENVIRONMENT "ECKIT_COLOUR_OUTPUT=1"
-		ARGS "--ignore-warn"
-                     "--ignore-error"
-                     "${IODA_YAML_ROOT}/validation/ObsSpace.yaml"
-                     "${f}"
-		)
-endforeach()
-
 ecbuild_install_project( NAME ${PROJECT_NAME} )
 ecbuild_print_summary()


### PR DESCRIPTION
## Description

Move ufo-data validate obs file logic to ufo.

## Issue(s) addressed

Resolves #514.

This may not be the best solution for #514, but is certainly the easiest to implement, as we are only moving the validation tests from ufo-data to ufo. With the test in ufo, it will now validate test data obtained from sources other than ufo-data.

## Dependencies

- JCSDA-internal/ufo#3897

build-group=JCSDA-internal/ufo#3897

## Impact

Validation of obs file moved to ufo.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation _-na-_
- [x] I have run the unit tests before creating the PR
