### PR TITLE
add mtg-irs test data for pcscore to radiance variable transform.

### DIFF
--- a/testinput_tier_1/PCscores_transform_mtg-irs_20210624.nc4
+++ b/testinput_tier_1/PCscores_transform_mtg-irs_20210624.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55a6618d726dc8c77f93b7402526df3fc58adb2c1e9121a4e1a33f2d325d9031
+size 850633

--- a/testinput_tier_1/resources/auxillary/mtg-irs_pcscores_reconstructor.nc4
+++ b/testinput_tier_1/resources/auxillary/mtg-irs_pcscores_reconstructor.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f2432ffe3aa5b1e1355276505502262a8c4545d27a72816a3495bbbed117eb8
+size 27683


### PR DESCRIPTION
## Description
PR associated with ufo pull request for supporting test data for ufo feature/add_mean_SatRadianceFromPCScores

build-group=https://github.com/JCSDA-internal/ufo-data/pull/

needed for ufo PR: https://github.com/JCSDA-internal/ufo/pull/#3895
## Issue(s) addressed
Resolves https://github.com/JCSDA-internal/ufo/issues/3741


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
