### PR TITLE
Update pathsum test data so that real electron density data can be used to compute vertical total electron content

### DIFF
--- a/testinput_tier_1/geovals_gridded_vtec_202010232345_100locs.nc4
+++ b/testinput_tier_1/geovals_gridded_vtec_202010232345_100locs.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e5e0aed330f870ad05a3593f292d74b96a8b6560f8acba3ed70853c2d136003
-size 329279

--- a/testinput_tier_1/geovals_gridded_vtec_202010232345_synthetic.nc4
+++ b/testinput_tier_1/geovals_gridded_vtec_202010232345_synthetic.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b68edb638d92107ac8e2e51ee89df9cd8f7510ebcb7a58479cf1b29d384acd52
-size 14375
+oid sha256:5a4ebae54f3b93f68ee404b8c43fc72c273191117bb7f8070dfa8d82f5d90146
+size 14132

--- a/testinput_tier_1/geovals_gridded_vtec_weights_202010232345_100locs.nc4
+++ b/testinput_tier_1/geovals_gridded_vtec_weights_202010232345_100locs.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2098d1e5fd7cd5d77642a161630c5248396b35ebb037df04b326ec10709620f
+size 1519636

--- a/testinput_tier_1/gnss_gridded_vtec_202010232345_100locs.nc4
+++ b/testinput_tier_1/gnss_gridded_vtec_202010232345_100locs.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b598e3e5b4657ad5b958a811785efca30d425842963a12ae228b40cb064c0caa
-size 23511
+oid sha256:2af45c28d10d7e81b395681df39d97eb9437014e4903db1fbdf11dcb6315fde2
+size 12896

--- a/testinput_tier_1/gnss_gridded_vtec_202010232345_synthetic.nc4
+++ b/testinput_tier_1/gnss_gridded_vtec_202010232345_synthetic.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91ce24a7e4bd00188d4f3bb42b8d931890ef7647641c6803731cfa0c0d5a6ef1
-size 11573
+oid sha256:b16c4472301c39306a50cb797347f550a1dd1ac6ef275522eec1f58b29c27874
+size 10393


### PR DESCRIPTION
## Description

Update pathsum test data so that real electron density data can be used to compute vertical total electron content. In addition, some mannualy created data sets are added so that some features can be tested, which the real observation testing files can't contribute yet. Mostly it is the test reference is updated to reflect the code refactoring changes. 

## Issue(s) addressed

Resolves [#<532>](https://github.com/JCSDA-internal/ufo-data/issues/532) and https://github.com/JCSDA-internal/ufo-data/issues/529

## Dependencies

[#3903](https://github.com/JCSDA-internal/ufo/pull/3903)



## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
