### PR TITLE
Added unit test data for RefNLPEP2D forward operator and associated variable transforms

### DIFF
--- a/testinput_tier_1/gnssro_geoval_2025070400_refnlpep2d.nc4
+++ b/testinput_tier_1/gnssro_geoval_2025070400_refnlpep2d.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96316104c7a031f19c7296978c59be2c33db650f277f87eee613b3a4dc617656
+size 1872181

--- a/testinput_tier_1/gnssro_obs_2025070400_refnlpep2d.nc4
+++ b/testinput_tier_1/gnssro_obs_2025070400_refnlpep2d.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08c63a1d15dcf90b5be2179b2d2ed0cc486d66081ee6f2a9d63d5ae68129974c
+size 99569

--- a/testinput_tier_1/gnssrorefractivitygradient_transforms.nc4
+++ b/testinput_tier_1/gnssrorefractivitygradient_transforms.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5199743202d54e60fbb92a79ba2c7e015326b2dc013ce3b0793a16b3da96fdf9
+size 116209

--- a/testinput_tier_1/nonlocalpseudoexcessphase_transforms.nc4
+++ b/testinput_tier_1/nonlocalpseudoexcessphase_transforms.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5680a8e2c3e0a32681bd708154b2d3ab2669c0a20f1a91b8a73d51f8ad83751f
+size 102882


### PR DESCRIPTION
## Description

This is the unit test data related to the RefNLPEP2D forward operator: anew 2D GNSSRO forward operator based on refractivity that simulates a path-integrated variable called nonLocalPseudoExcessPhase.

## Issue(s) addressed

There is no issue number associated with this PR.

## Dependencies

The is related to a PR in ufo that provides the code for RefNLPEP2D. It is also related to a documentation PR in jedi-docs.

List the other PRs that this PR is dependent on:
- [https://github.com/JCSDA/ufo/pull/77] ...
- [https://github.com/JCSDA/jedi-docs/pull/47] .. 

## Impact

No downstream impact is expected. This PR only adds new unit test data files. It makes no changes to existing files.

## Manual Testing Instructions (optional)
These are the new ufo unit tests that are related to these data files:
* ufo_test_tier1_test_ufo_opr_gnssrorefnlpep2d
* ufo_test_tier1_test_ufo_linopr_gnssrorefnlpep2d
* ufo_test_tier1_test_ufo_variabletransforms_nonlocalpseudoexcessphase
* ufo_test_tier1_test_ufo_variabletransforms_gnssrorefractivitygradient

The ufo-data units tests are:
* ufo_data_validate_gnssro_obs_2025070400_refnlpep2d.nc4
* ufo_data_validate_nonlocalpseudoexcessphase_transforms.nc4
* ufo_data_validate_gnssrorefractivitygradient_transforms.nc4

## Checklist

- [ X] I have performed a self-review of my own code
- [X ] I have made corresponding changes to the documentation
- [X ] I have run the unit tests before creating the PR
