### PR TITLE
Rename ice variables in the geovals files

### DIFF
--- a/testinput_tier_1/cryosat2-2018-04-15_geovals.nc
+++ b/testinput_tier_1/cryosat2-2018-04-15_geovals.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e386c7b91ab80b8b7d0a18aad9c5723fa8d4f0d3c3e4d66b5f3e08d9e09f224f
+oid sha256:5f2d8e3ae10c6e2a1585ce07737aa4315dd20491add654ce78a867a77b53ec3a
 size 711960


### PR DESCRIPTION
## Description

This update geovals names for sea ice variables for the file used in SeaIceThickness operator to be consistent with expected variable names:
sea_ice_category_area_fraction -> sea_ice_area_fraction
sea_ice_category_thickness -> sea_ice_thickness
sea_ice_category_snow_thickness -> sea_ice_snow_thickness

Update for a [ufo PR3942](https://github.com/JCSDA-internal/ufo/pull/3942)