### PR TITLE
Add new references for changed k1 and k2 refractivity coefficients

### DIFF
--- a/testinput_tier_1/gnssro_obs_2019050700_1obs.nc4
+++ b/testinput_tier_1/gnssro_obs_2019050700_1obs.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0fd4ec6a776437f2d202b443a28058b4a9096c93cfddeae819842b47f1a85d3
-size 53572
+oid sha256:c45a76f3e911a25152284c6186c05f3f00f0646b8a7f8e74b0070edecfe2f285
+size 40039

--- a/testinput_tier_1/gnssro_obs_2019123006_refractivity.nc4
+++ b/testinput_tier_1/gnssro_obs_2019123006_refractivity.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ca47f2fa027a897487566963139f31a300110521e7de61197c4157d077e32e1
-size 61269
+oid sha256:23b099d3dce74b3cbaef80daaced33d7c8ea5d3f8618e3d1d325f421f64bfc26
+size 72965


### PR DESCRIPTION
## Description

This is companion PR to https://github.com/JCSDA-internal/ufo/pull/3955. It provides the reference data for the new ctests to be measured against.

## Issue(s) addressed

-

## Dependencies

None (provides additional data for ufo PR https://github.com/JCSDA-internal/ufo/pull/3955

## Impact

Expected impact on downstream repositories: None

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
