### PR TITLE
ATOVs update the test reference value

### DIFF
--- a/testinput_tier_1/obs_atovs_transmittance_20210701T1200Z.nc4
+++ b/testinput_tier_1/obs_atovs_transmittance_20210701T1200Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35d5b79bc195bbe9b006175c8657d0fe4aad32fec7213116f86220f6630b87ae
-size 109627
+oid sha256:3665a54a001ba17020e0aa9be56d6bf1791eb21d686034d8a6c4c5f2321e2af2
+size 68756


### PR DESCRIPTION
## Description

This PR updates the test reference data because of a change in the ufo code and ctest.  The UFO code in the linked PR has been updated to fill the `OneDVar/transmittance` values with missing values unless the 1D-Var profile converges and then the correct values are written out.  In order to test this I have modified the tests that use this file to have fewer minimisations and a tighter criteria in order to get a profile to fail.  

Therefore the update in this PR is to modify the `TestReferenceOneDVar/transmittance` values.

## Issue(s) addressed

[Issue in UFO](https://github.com/JCSDA-internal/ufo/issues/4016)

## Dependencies

To be merged with the associated UFO PR:
- [ ] https://github.com/JCSDA-internal/ufo/pull/4017

## Impact

More consistent output for the `OneDVar/transmittance` values.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
