### PR TITLE
Update GsiHofX reference for RadarRadialVelocity operator bugfix

### DIFF
--- a/testinput_tier_1/radar_rw_obs_2020101300_m.nc
+++ b/testinput_tier_1/radar_rw_obs_2020101300_m.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9cf2b7b1909cdd97347192b8228e31ba75f8c2f47e778dd7ac5aabb682dcfa4
+oid sha256:e3e7e8303d8d05b00b02b5e99206480d1c0f52ab63ccf7db6b3f62a522065b6d
 size 41448


### PR DESCRIPTION
## Description

Companion PR to [JCSDA-internal/ufo#4019](https://github.com/JCSDA-internal/ufo/pull/4019).

Updates the `GsiHofX/radialVelocity` reference values in `testinput_tier_1/radar_rw_obs_2020101300_m.nc` to match the corrected RadarRadialVelocity operator output (azimuth convention fix + vertical velocity term in TL/AD).

## Files Changed

- `testinput_tier_1/radar_rw_obs_2020101300_m.nc` — updated GsiHofX reference values