### PR TITLE
Update files for the three failing level 2 rttov ctests

### DIFF
--- a/testinput_tier_1/atms_n20_obs_20191230T0000_rttov_v14.nc4
+++ b/testinput_tier_1/atms_n20_obs_20191230T0000_rttov_v14.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec87451be25c97773909a2e75f86cf2a50508b586a6f81e03bf86bc21ea47417
-size 107593
+oid sha256:9e2f217a1f48dee163022bb06c5d6662b5c2d749aa47117b98855dcb780edb89
+size 107395

--- a/testinput_tier_1/atms_n20_obs_20191230T0000_rttov_v14.nc4
+++ b/testinput_tier_1/atms_n20_obs_20191230T0000_rttov_v14.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e2f217a1f48dee163022bb06c5d6662b5c2d749aa47117b98855dcb780edb89
+oid sha256:3ef84b482e202b8cccd620551ab7f298c142efecd9a05ec100ae0e27acbcbc53
 size 107395

--- a/testinput_tier_1/atovs_obs_2021011512_multiplatform.nc4
+++ b/testinput_tier_1/atovs_obs_2021011512_multiplatform.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e69dd923047c9db0711fcd7e5a1f7c4f8c7ffc25408b5afda0102b7801431b3a
-size 367714
+oid sha256:33a54c054c304a58a1f1bcfcf14fab7734af4d5ae6b2bde2ae2cbfdbc386ed1a
+size 184728

--- a/testinput_tier_1/atovs_obs_2021011512_multiplatform.nc4
+++ b/testinput_tier_1/atovs_obs_2021011512_multiplatform.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33a54c054c304a58a1f1bcfcf14fab7734af4d5ae6b2bde2ae2cbfdbc386ed1a
-size 184728
+oid sha256:e69dd923047c9db0711fcd7e5a1f7c4f8c7ffc25408b5afda0102b7801431b3a
+size 367714

--- a/testinput_tier_1/atovs_obs_2021011512_multiplatform_v14.nc4
+++ b/testinput_tier_1/atovs_obs_2021011512_multiplatform_v14.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e69dd923047c9db0711fcd7e5a1f7c4f8c7ffc25408b5afda0102b7801431b3a
+size 367714


### PR DESCRIPTION
## Description

This PR adds a v14 specific file and updates one in order to resolve the ufo failing ctests introduced with rttov 14.

## Issue(s) addressed

Resolves [ufo#4038](https://github.com/JCSDA-internal/ufo/issues/4038)

## Dependencies

To be merged with the associated ufo PR:
- [ ] https://github.com/JCSDA-internal/ufo/pull/4041

## Impact

All rttov ctests should pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation. NA
- [x] I have run the unit tests before creating the PR
