### PR TITLE
Create new file - single profile with super-refraction near bottom of model profile

### DIFF
--- a/testinput_tier_1/gnssro_geoval_2022090100_1prof.nc4
+++ b/testinput_tier_1/gnssro_geoval_2022090100_1prof.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57bdebadfede2138dff5f953470a0e5d4c5fc7f2f70b70261960d1cd05c12166
-size 895578
+oid sha256:2d3d8a5ff49d2c029cc8b7b3d62d3a15409ad00742b360394ccff8e89f309028
+size 317940

--- a/testinput_tier_1/gnssro_geoval_2022090100_1prof.nc4
+++ b/testinput_tier_1/gnssro_geoval_2022090100_1prof.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57bdebadfede2138dff5f953470a0e5d4c5fc7f2f70b70261960d1cd05c12166
+size 895578

--- a/testinput_tier_1/gnssro_obs_2022090100_1prof.nc4
+++ b/testinput_tier_1/gnssro_obs_2022090100_1prof.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd0f697f81d59faacb109c9b88fdb4d9fd5283ecbe7c68e705fcd24fd66d1cac
+size 44510


### PR DESCRIPTION
## Description

Companion PR to https://github.com/JCSDA-internal/ufo/pull/4083

Introduces new files for a single profile, derived from the `6prof` GNSS-RO file. This profile contains super-refraction at the bottom of the model profile, meaning that it is good for testing the no-super-check option.

## Issue(s) addressed

None

## Dependencies

None

## Impact

None

## Checklist

- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
