### PR TITLE
Deflate large GNSS RO data files

### DIFF
--- a/testinput_tier_1/gnssro_geoval_2018041500_3prof.nc4
+++ b/testinput_tier_1/gnssro_geoval_2018041500_3prof.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:255fe29e3c65e552229cd3f762f556eac878b7afb6a76a3bf9e505d700eb6153
-size 1468124
+oid sha256:139c2b0892e8f6c7ce96a7c701627adf009f3e17762ad37b2ad5cd00aa797eb7
+size 496606

--- a/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
+++ b/testinput_tier_1/gnssro_geoval_6prof_2022090100.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf9658ba454965aff350ccee9eea036ae23671c4d7d8912de4b040bd04ef9936
-size 5237110
+oid sha256:d30108f88ce0956feafe823b243b81d129ad31666a0af54cdee81d9af6bd6bbc
+size 2023857


### PR DESCRIPTION
## Description

This is a start to clean up/enhance the GNSS RO files in the test data.
This PR deflated a couple large than 1M files. Related tests passed. 

size changes:
5M -> 2M gnssro_geoval_6prof_2022090100.nc4 
1.5M -> 488 K gnssro_geoval_2018041500_3prof.nc4

Notes to self:
gnssro_obs_2018041500_3prof_avtemp.nc4
gnssro_geoval_2018041500_3prof_avtemp.nc4

## Issue(s) addressed

Resolves  https://github.com/JCSDA-internal/ufo-data/issues/559

## Dependencies
N/A

## Impact
should be N/A

## Manual Testing Instructions (optional)

ctest -R gnssro

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
