### PR TITLE
Add P-PRO NSSL test data files

### DIFF
--- a/testinput_tier_1/ppro_nssl_geovals.nc
+++ b/testinput_tier_1/ppro_nssl_geovals.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4db4e440850f24a7cd71689170a8a16343d7960750f1babbaa91032fc7b0b338
+size 418360

--- a/testinput_tier_1/ppro_nssl_obs.nc
+++ b/testinput_tier_1/ppro_nssl_obs.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6ffd52fcc666db9b2b97d8da5711baaf9031bcc25ef82c2d3b2b77e69aeaf7
+size 22658

--- a/testinput_tier_1/ppro_tcwa2_geovals.nc
+++ b/testinput_tier_1/ppro_tcwa2_geovals.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73605d1bf53fb45f5ac3da3bcbe98967cbb748c07a9599cbd751cb980778b785
+size 445514

--- a/testinput_tier_1/ppro_tcwa2_obs.nc
+++ b/testinput_tier_1/ppro_tcwa2_obs.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ebe96979fd730b682950bbbc407b1fad59f93a50d6ebf7daed161596ea5b117
+size 22658


### PR DESCRIPTION
Add sample obs and geovals files for P-PRO polarimetric radar operator unit test (ppro_nssl). Companion to JCSDA-internal/ufo#4107.

## Description
  Add test data files for P-PRO (Polarimetric Radar Operator) unit test:
  - `testinput_tier_1/ppro_nssl_geovals.nc` - GeoVaLs data
  - `testinput_tier_1/ppro_nssl_obs.nc` - Observation data

## Issue(s) addressed
Companion PR to JCSDA-internal/ufo#4107

## Dependencies
List the other PRs that this PR is dependent on:
- [x] JCSDA-internal/ufo#4107 (P-PRO operator PR) 

## Impact
None on downstream repositories. Test data only.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
