### PR TITLE
Test reference updates for use of proper dimList parameter of the ObsSpace::put_db function

### DIFF
--- a/testinput_tier_1/multichannel_variable_assignment_testdata.nc
+++ b/testinput_tier_1/multichannel_variable_assignment_testdata.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:704a1c4b43428f386ff9accbb0e74d32bf026d9972997d2ef22d0dc2134901ac
-size 90382
+oid sha256:2e3a5a461c8e256701d04c5291f36d3f630734a9e8202d8fe477ebfbd0e96951
+size 24040


### PR DESCRIPTION
## Description

This PR provides updates related to the usage of the dimList parameter

## Issue(s) addressed

Partially addresses jcsda-internal/ioda/issues/1730

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] Merge with jcsda-internal/oops/pull/3281
- [ ] Merge with jcsda-internal/ufo/pull/4126
- [ ] Merge with jcsda-internal/ioda/pull/1731
- [ ] Merge with jcsda-internal/ioda-data/pull/242

## Impact

Expected impact on downstream repositories:

Only changes feedback files for OSDF based workflows (which are not in general use yet)

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
