### PR TITLE
Add P-PRO test data for opr_ppro_nssl and opr_ppro_tcwa2 ctests

### DIFF
--- a/testinput_tier_1/ppro_nssl_geovals.nc
+++ b/testinput_tier_1/ppro_nssl_geovals.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4db4e440850f24a7cd71689170a8a16343d7960750f1babbaa91032fc7b0b338
+size 418360

--- a/testinput_tier_1/ppro_nssl_obs.nc
+++ b/testinput_tier_1/ppro_nssl_obs.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6ffd52fcc666db9b2b97d8da5711baaf9031bcc25ef82c2d3b2b77e69aeaf7
+size 22658

--- a/testinput_tier_1/ppro_nssl_obs.nc
+++ b/testinput_tier_1/ppro_nssl_obs.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe637ab0792c7e9a57e192296fea66f95f44c6c5641fca4bd32b28616e5871ba
+oid sha256:9cb14e6dd45964cface5c9baa86f234c5967ebc05f776e781ddad533b75cebe5
 size 22658

--- a/testinput_tier_1/ppro_nssl_obs.nc
+++ b/testinput_tier_1/ppro_nssl_obs.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c6ffd52fcc666db9b2b97d8da5711baaf9031bcc25ef82c2d3b2b77e69aeaf7
+oid sha256:fe637ab0792c7e9a57e192296fea66f95f44c6c5641fca4bd32b28616e5871ba
 size 22658

--- a/testinput_tier_1/ppro_tcwa2_geovals.nc
+++ b/testinput_tier_1/ppro_tcwa2_geovals.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73605d1bf53fb45f5ac3da3bcbe98967cbb748c07a9599cbd751cb980778b785
+size 445514

--- a/testinput_tier_1/ppro_tcwa2_obs.nc
+++ b/testinput_tier_1/ppro_tcwa2_obs.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ebe96979fd730b682950bbbc407b1fad59f93a50d6ebf7daed161596ea5b117
+size 22658

--- a/testinput_tier_1/ppro_tcwa2_obs.nc
+++ b/testinput_tier_1/ppro_tcwa2_obs.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2e927ab352d97da88f3af22a1a7a18d7ab0c1cfd5956ddef63ae5a2f52abc17
+oid sha256:078fba966cf0d1c5610427480fcdae6ebbce57e58d2912dc2412336d5101aab7
 size 22658

--- a/testinput_tier_1/ppro_tcwa2_obs.nc
+++ b/testinput_tier_1/ppro_tcwa2_obs.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ebe96979fd730b682950bbbc407b1fad59f93a50d6ebf7daed161596ea5b117
+oid sha256:b2e927ab352d97da88f3af22a1a7a18d7ab0c1cfd5956ddef63ae5a2f52abc17
 size 22658


### PR DESCRIPTION
  ## Description
  Parameterized Polarimetric Radar Operator (P-PRO) includes two operator options: Zhang21 and TCWA2.
  Test data files for PPRO ctest:
  - `ppro_nssl_obs.nc`, `ppro_nssl_geovals.nc` for `opr_ppro_nssl` (test for Zhang21 operator in P-PRO coupled with NSSL MP scheme)
  - `ppro_tcwa2_obs.nc`, `ppro_tcwa2_geovals.nc` for `opr_ppro_tcwa2` (test for TCWA2 operator in P-PRO coupled with TCWA2 MP scheme)
  Used by JCSDA-internal/ufo#4107
  ## Dependencies
  List the other PRs that this PR is dependent on:
  - [x] none
  ## Impact
  Expected impact on downstream repositories:
  Required by JCSDA-internal/ufo#4107 to enable the new `ufo_opr_ppro_nssl` and `ufo_opr_ppro_tcwa2` ctests.
  ## Checklist
  - [x] I have performed a self-review of my own code
  - [x] I have made corresponding changes to the documentation
  - [x] I have run the unit tests before creating the PR