### PR TITLE
Update JEDI CI action with build cache

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -38,7 +38,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Run JEDI CI
-        uses: JCSDA-internal/jedi-ci@feature/oops-fixes
+        uses: JCSDA-internal/jedi-ci@v2
         with:
           container_version: 'latest'
           unittest_tag: 'ufo'

--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -43,7 +43,5 @@ jobs:
           container_version: 'latest'
           unittest_tag: 'ufo'
           test_script: run_tests.sh
-          target_repo_dir: target_repository
           bundle_branch: develop
           jedi_ci_token: ${{ steps.generate-token.outputs.token }}
-          test_dependencies: crtm ioda ioda-data oops gsw ufo-data oasim ropp-ufo rttov


### PR DESCRIPTION
Update to jedi-ci v2 with caching

run-ci-on-draft = true

Issue: https://github.com/JCSDA-internal/jedi-ci/issues/77
