### PR TITLE
Merge release/1.13 into develop (2026.1.0 back-merge)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( ufo-data VERSION 1.10.0 DESCRIPTION "UFO Test Files" )
+project( ufo-data VERSION 1.13.0 DESCRIPTION "UFO Test Files" )
 
 find_package( ecbuild QUIET )
 include( ecbuild_system NO_POLICY_SCOPE )


### PR DESCRIPTION
Back-merge of the 2026.1.0 release branch. Contains project VERSION bump and find_package version bumps for peer components.

Refs JCSDA-internal/jedi-bundle#153.