### PR TITLE
update surface_{geovals,obs}_20210521T1200Z.nc4 for the updated `ModelHeightAdjustedAirTemperature` obsfunction

### DIFF
--- a/testinput_tier_1/surface_geovals_20210521T1200Z.nc4
+++ b/testinput_tier_1/surface_geovals_20210521T1200Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:617586444ba86cca5d5fa9e5cd2461f355571be85ef89ca0c6fb82db6f8706ed
-size 14215
+oid sha256:e23b7e115f393bbe17b2eabcc6355df5a9dc33ef781dbbe79c6db5cfbeaa4f3a
+size 11382

--- a/testinput_tier_1/surface_geovals_20210521T1200Z.nc4
+++ b/testinput_tier_1/surface_geovals_20210521T1200Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f9084ac8e59e5f6b51c4e88176e3799c6e85a1cb7e65d56fa3d7ccb85a76d8e
-size 9574
+oid sha256:617586444ba86cca5d5fa9e5cd2461f355571be85ef89ca0c6fb82db6f8706ed
+size 14215

--- a/testinput_tier_1/surface_obs_20210521T1200Z.nc4
+++ b/testinput_tier_1/surface_obs_20210521T1200Z.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f7cec2a544ea09841fbf64fe90fc2d47e89ab066115e09b7082e12d6759e6a2
-size 50918
+oid sha256:b711d4cf85ad9dec844e81c8ef8fedac464d28381fd50d72841fbb4eab8f64f4
+size 53238


### PR DESCRIPTION
## Description

PR https://github.com/JCSDA-internal/ufo/pull/4238 updates the `ModelHeightAdjustedAirTemperature` obsfunction to allow configurable constant or local lapse rates.  New unit tests are added for the new capabilities. 
For these new unit tests, we need to add new `TestReference/variables` into `surface_obs_20210521T1200Z.nc4`,  add ` height_above_mean_sea_level(nlocs, nlevs)` and `air_temperature(nlocs, nlevs)` to `surface_geovals_20210521T1200Z.nc4`

## Issue(s) addressed

Resolves https://github.com/JCSDA-internal/ufo/issues/4181

## Dependencies

List the other PRs that this PR is dependent on:
 - None

## Impact

Expected impact on downstream repositories: None

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
